### PR TITLE
Make neon aware of pg_csn

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -399,6 +399,8 @@ impl PostgresNode {
             conf.append("synchronous_standby_names", "pageserver");
         }
 
+        // UMD: Remotexact and multi-region configurations
+        conf.append("enable_csn_snapshot", "on");
         // TODO(ctring): consider a different value or make this an argument somewhere
         conf.append("max_prepared_transactions", "64");
         conf.append(

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -217,10 +217,11 @@ pub const PG_MAJORVERSION: &str = "14";
 
 // List of subdirectories inside pgdata.
 // Copied from src/bin/initdb/initdb.c
-pub const PGDATA_SUBDIRS: [&str; 22] = [
+pub const PGDATA_SUBDIRS: [&str; 23] = [
     "global",
     "pg_wal/archive_status",
     "pg_commit_ts",
+    "pg_csn",
     "pg_dynshmem",
     "pg_notify",
     "pg_serial",

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -152,6 +152,7 @@ where
             SlruKind::Clog,
             SlruKind::MultiXactOffsets,
             SlruKind::MultiXactMembers,
+            SlruKind::Csn,
         ] {
             for segno in self.timeline.list_slru_segments(kind, self.lsn)? {
                 self.add_slru_segment(kind, segno)?;

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -517,6 +517,11 @@ fn import_file<Reader: Read>(
 
         import_slru(modification, slru, file_path, reader, len)?;
         debug!("imported multixact members slru");
+    } else if file_path.starts_with("pg_csn") {
+        let slru = SlruKind::Csn;
+
+        import_slru(modification, slru, file_path, reader, len)?;
+        debug!("imported csn slru");
     } else if file_path.starts_with("pg_twophase") {
         let file_name = &file_path
             .file_name()

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -424,6 +424,7 @@ impl Timeline {
             SlruKind::Clog,
             SlruKind::MultiXactMembers,
             SlruKind::MultiXactOffsets,
+            SlruKind::Csn,
         ] {
             let slrudir_key = slru_dir_to_key(kind);
             result.add_key(slrudir_key);
@@ -543,7 +544,11 @@ impl<'a> DatadirModification<'a> {
             slru_dir_to_key(SlruKind::MultiXactMembers),
             empty_dir.clone(),
         );
-        self.put(slru_dir_to_key(SlruKind::MultiXactOffsets), empty_dir);
+        self.put(
+            slru_dir_to_key(SlruKind::MultiXactOffsets),
+            empty_dir.clone(),
+        );
+        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir);
 
         Ok(())
     }
@@ -1216,6 +1221,7 @@ fn slru_dir_to_key(kind: SlruKind) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 0,
         field4: 0,
@@ -1231,6 +1237,7 @@ fn slru_block_to_key(kind: SlruKind, segno: u32, blknum: BlockNumber) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 1,
         field4: segno,
@@ -1246,6 +1253,7 @@ fn slru_segment_size_to_key(kind: SlruKind, segno: u32) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 1,
         field4: segno,
@@ -1259,6 +1267,7 @@ fn slru_segment_key_range(kind: SlruKind, segno: u32) -> Range<Key> {
         SlruKind::Clog => 0x00,
         SlruKind::MultiXactMembers => 0x01,
         SlruKind::MultiXactOffsets => 0x02,
+        SlruKind::Csn => 0x03,
     };
 
     Key {
@@ -1368,6 +1377,7 @@ pub fn key_to_slru_block(key: Key) -> Result<(SlruKind, u32, BlockNumber)> {
                 0x00 => SlruKind::Clog,
                 0x01 => SlruKind::MultiXactMembers,
                 0x02 => SlruKind::MultiXactOffsets,
+                0x03 => SlruKind::Csn,
                 _ => bail!("unrecognized slru kind 0x{:02x}", key.field2),
             };
             let segno = key.field4;

--- a/pageserver/src/reltag.rs
+++ b/pageserver/src/reltag.rs
@@ -129,6 +129,7 @@ pub enum SlruKind {
     Clog,
     MultiXactMembers,
     MultiXactOffsets,
+    Csn,
 }
 
 impl SlruKind {
@@ -137,6 +138,7 @@ impl SlruKind {
             Self::Clog => "pg_xact",
             Self::MultiXactMembers => "pg_multixact/members",
             Self::MultiXactOffsets => "pg_multixact/offsets",
+            Self::Csn => "pg_csn",
         }
     }
 }


### PR DESCRIPTION
+ Create a new SLRU kind in neon
+ Switch vendor to the csn commit

Before:
Postgres in neon failed to start due to:
```
2022-08-26 18:59:30.867 GMT [13648] FATAL:  could not open directory "pg_csn": No such file or directory
```
After:
Postgres can start successfully