### PR TITLE
LSN for DbSize Message & bring back setting LSN on remote pages.

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -142,6 +142,7 @@ struct PagestreamErrorResponse {
 
 #[derive(Debug)]
 struct PagestreamDbSizeResponse {
+    lsn: Lsn,
     db_size: i64,
 }
 
@@ -252,6 +253,7 @@ impl PagestreamBeMessage {
             }
             Self::DbSize(resp) => {
                 bytes.put_u8(104); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put_i64(resp.db_size);
             }
         }
@@ -795,6 +797,7 @@ impl PageServerHandler {
         let db_size = total_blocks as i64 * BLCKSZ as i64;
 
         Ok(PagestreamBeMessage::DbSize(PagestreamDbSizeResponse {
+            lsn,
             db_size,
         }))
     }

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -30,11 +30,6 @@
 		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
 		 errhidestmt(true), errhidecontext(true)))
 
-#define NEON_TAG "[NEON_SMGR] "
-#define neon_log(tag, fmt, ...) ereport(tag, \
-		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
-		 errhidestmt(true), errhidecontext(true)))
-
 /* GUCs */
 char *neon_region_timelines;
 
@@ -121,8 +116,9 @@ init_region_lsns()
 }
 
 /*
- * Set the LSN for a given region if it wasn't previously set. The set LSN is use
- * for that region throughout the life of the transaction.
+ * Set the LSN for a given region if it wasn't previously set. 
+ * This LSN is used in Neon requests for that region throughout
+ * the life of the current transaction.
  */
 void
 set_region_lsn(int region, NeonResponse *msg)
@@ -147,6 +143,9 @@ set_region_lsn(int region, NeonResponse *msg)
 			break;
 		case T_NeonGetSlruPageResponse:
 			lsn = ((NeonGetSlruPageResponse *) msg)->lsn;
+			break;
+		case T_NeonDbSizeResponse:
+			lsn = ((NeonDbSizeResponse *) msg)->lsn;
 			break;
 		case T_NeonErrorResponse:
 			break;

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -144,6 +144,7 @@ typedef struct
 typedef struct
 {
 	NeonMessageTag tag;
+	XLogRecPtr	lsn;
 	int64		db_size;
 }			NeonDbSizeResponse;
 

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -311,6 +311,7 @@ nm_unpack_response(StringInfo s)
 				NeonDbSizeResponse *msg_resp = palloc0(sizeof(NeonDbSizeResponse));
 
 				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 				msg_resp->db_size = pq_getmsgint64(s);
 				pq_getmsgend(s);
 
@@ -526,6 +527,7 @@ nm_to_string(NeonMessage * msg)
 				NeonDbSizeResponse *msg_resp = (NeonDbSizeResponse *) msg;
 
 				appendStringInfoString(&s, "{\"type\": \"NeonDbSizeResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
 				appendStringInfo(&s, ", \"db_size\": %ld}",
 								 msg_resp->db_size);
 				appendStringInfoChar(&s, '}');
@@ -1278,20 +1280,24 @@ static void neon_read_at_lsn_multi_region(RelFileNode rnode, ForkNumber forkNum,
 	{
 		case T_NeonGetPageResponse:
 			memcpy(buffer, ((NeonGetPageResponse *) resp)->page, BLCKSZ);
-			// TODO (ctring): potential optimization, but need more testing before uncommenting
-			// if (RegionIsRemote(region))
-			// {
-			// 	XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
-			// 	/*
-			// 	 * Set the LSN on the page to be equal to the LSN snapshot of the current transaction
-			// 	 * so that we don't need to evict the page from local buffer if we use the same LSN
-			// 	 * snapshot for the subsequent transactions.
-			// 	 * Only do this when the LSN is not 0, otherwise an all-zero page will be dirtied and
-			// 	 * not recognized as all-zero by PageIsVerifiedExtended.
-			// 	 */
-			// 	if (PageGetLSN((Page) buffer) != 0)
-			// 		PageSetLSN((Page) buffer, lsn);
-			// }
+			if (RegionIsRemote(region))
+			{
+				XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
+				/*
+				 * Set the LSN on the page to be equal to the LSN snapshot of the current transaction
+				 * so that we don't need to evict the page from local buffer if we use the same LSN
+				 * snapshot for the subsequent transactions.
+				 * 
+				 * When a page is requested to insert tuples, neon may response with an all-zero
+				 * page if the page does not exist previously (e.g. the relation is empty). The function
+				 * PageIsVerifiedExtended checks either the checksum of a page is valid or the page
+				 * is all-zero. If we set the LSN for an all-zero page, that function will consider the
+				 * page invalid, so we only set the LSN if the the LSN of the page is not zero, meaning
+				 * the page is not an all-zero page. 
+				 */
+				if (PageGetLSN((Page) buffer) != 0)
+					PageSetLSN((Page) buffer, lsn);
+			}
 			break;
 
 		case T_NeonErrorResponse:

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -249,9 +249,6 @@ rx_collect_update(Relation relation, HeapTuple oldtuple, HeapTuple newtuple)
 
 	init_rwset_collection_buffer(relation->rd_node.dbNode);
 
-	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
-	// to collect the write set. Need to figure out a way to get rid of this step
-	// or a check to prevent us from forgetting to do this step.
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)
@@ -306,9 +303,6 @@ rx_collect_delete(Relation relation, HeapTuple oldtuple)
 
 	init_rwset_collection_buffer(relation->rd_node.dbNode);
 
-	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
-	// to collect the write set. Need to figure out a way to get rid of this step
-	// or a check to prevent us from forgetting to do this step.
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)


### PR DESCRIPTION
DbSize is a new message in neon that has not had the LSN field so adding it now.

