### PR TITLE
Remove timeline id list from multipagestream

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -66,10 +66,10 @@ pageserver_connect()
 				 errdetail_internal("%s", msg)));
 	}
 
-	if (neon_multiregion_enabled())
+	if (IsMultiRegion())
 	{
-		neon_log(LOG, "multi-region enabled, timelines: %s", neon_region_timelines);
-		query = psprintf("multipagestream %s %s", neon_tenant, neon_region_timelines);
+		neon_log(LOG, "multi-region enabled");
+		query = psprintf("multipagestream %s", neon_tenant);
 	}
 	else
 		query = psprintf("pagestream %s %s", neon_tenant, neon_timeline);
@@ -481,8 +481,6 @@ pg_init_libpagestore(void)
 							 PGC_POSTMASTER,
 							 0, /* no flags required */
 							 NULL, NULL, NULL);
-
-	DefineMultiRegionCustomVariables();
 
 	relsize_hash_init();
 

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -30,90 +30,7 @@
 		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
 		 errhidestmt(true), errhidecontext(true)))
 
-/* GUCs */
-char *neon_region_timelines;
-
-static XLogRecPtr	*region_lsns = NULL;
-static int	num_regions = 1;
-
-static bool
-check_neon_region_timelines(char **newval, void **extra, GucSource source)
-{
-	char *rawstring;
-	List *timelines;
-	ListCell *l;
-	uint8 zid[16];
-
-	/* Need a modifiable copy of string */
-	rawstring = pstrdup(*newval);
-
-	/* Parse string into list of timeline ids */
-	if (!SplitIdentifierString(rawstring, ',', &timelines))
-	{
-		/* syntax error in list */
-		GUC_check_errdetail("List syntax is invalid.");
-		pfree(rawstring);
-		list_free(timelines);
-		return false;
-	}
-
-	/* Check if the given timeline ids are valid */
-	foreach (l, timelines)
-	{
-		char *tok = (char *)lfirst(l);
-
-		/* Taken from check_zenith_id in libpagestore.c */
-		if (*tok != '\0' && !HexDecodeString(zid, tok, 16))
-		{
-			GUC_check_errdetail("Invalid Zenith id: \"%s\".", tok);
-			pfree(rawstring);
-			list_free(timelines);
-			return false;
-		}
-	}
-
-	*extra = malloc(sizeof(int));
-	if (!*extra)
-		return false;
-
-	*((int *) *extra) = list_length(timelines);
-
-	pfree(rawstring);
-	list_free(timelines);
-	return true;
-}
-
-static void assign_neon_region_timelines(const char *newval, void *extra)
-{
-	/* Add 1 for the global region */
-	num_regions = *((int *) extra) + 1;
-}
-
-
-void DefineMultiRegionCustomVariables(void)
-{
-	DefineCustomStringVariable("neon.region_timelines",
-								"List of timelineids corresponding to the partitions",
-								NULL,
-								&neon_region_timelines,
-								"",
-								PGC_POSTMASTER,
-								GUC_LIST_INPUT,
-								check_neon_region_timelines, assign_neon_region_timelines, NULL);
-}
-
-bool neon_multiregion_enabled(void)
-{
-	return neon_region_timelines && neon_region_timelines[0];
-}
-
-static void
-init_region_lsns()
-{
-	region_lsns = (XLogRecPtr *)
-			MemoryContextAllocZero(TopTransactionContext,
-								   num_regions * sizeof(XLogRecPtr));
-}
+static XLogRecPtr	region_lsns[MAX_REGIONS];
 
 /*
  * Set the LSN for a given region if it wasn't previously set. 
@@ -128,7 +45,7 @@ set_region_lsn(int region, NeonResponse *msg)
 	if (!IsMultiRegion() || !RegionIsRemote(region))
 		return;
 
-	AssertArg(region < num_regions);
+	AssertArg(region < MAX_REGIONS);
 
 	switch (messageTag(msg))
 	{
@@ -156,9 +73,6 @@ set_region_lsn(int region, NeonResponse *msg)
 
 	Assert(lsn != InvalidXLogRecPtr);
 
-	if (region_lsns == NULL)
-		init_region_lsns();
-
 	if (region_lsns[region] == InvalidXLogRecPtr)
 		region_lsns[region] = lsn;
 	else
@@ -176,10 +90,7 @@ get_region_lsn(int region)
 	
 	// LSN of the current region is already tracked by postgres
 	AssertArg(region != current_region);
-	AssertArg(region < num_regions);
-
-	if (region_lsns == NULL)
-		init_region_lsns();
+	AssertArg(region < MAX_REGIONS);
 
 	return region_lsns[region];
 }
@@ -187,7 +98,9 @@ get_region_lsn(int region)
 void
 clear_region_lsns(void)
 {
-	/* The data is destroyed along with the transaction
-		context so only need to set this to NULL */
-	region_lsns = NULL;
+	int i;
+	for (i = 0; i < MAX_REGIONS; i++)
+	{
+		region_lsns[i] = InvalidXLogRecPtr;
+	}
 }

--- a/pgxn/neon/multiregion.h
+++ b/pgxn/neon/multiregion.h
@@ -14,10 +14,6 @@
 #include "access/xlogdefs.h"
 #include "pagestore_client.h"
 
-extern char *neon_region_timelines;
-
-extern void DefineMultiRegionCustomVariables(void);
-extern bool neon_multiregion_enabled(void);
 extern void set_region_lsn(int region, NeonResponse *msg);
 extern XLogRecPtr get_region_lsn(int region);
 extern void clear_region_lsns(void);

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -66,7 +66,7 @@ typedef struct
 	NeonMessageTag tag;
 	bool		latest;			/* if true, request latest page version */
 	XLogRecPtr	lsn;			/* request page version @ this LSN */
-	int			region;			/* region to fetch page from */
+	int8    	region;			/* region to fetch page from */
 }			NeonRequest;
 
 typedef struct

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -181,7 +181,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -195,7 +195,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -219,7 +219,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -234,7 +234,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendbyte(&s, msg_req->kind);
 				pq_sendint32(&s, msg_req->segno);
 				pq_sendint32(&s, msg_req->blkno);


### PR DESCRIPTION
Postgres doesn't need to know about the timeline-region mapping anymore. It just need to tell neon which which region it need to fetch the page from and neon will figure it out itself.