### PR TITLE
Disable caching relsize for remote relations

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -376,7 +376,7 @@ impl PostgresNode {
             // testing.
             conf.append("synchronous_standby_names", "pageserver");
         }
-        
+
         //
         // Remotexact: multi-region configurations
         //

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -191,13 +191,16 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
 
     let tenant = tenant_mgr::get_tenant(tenant_id, true).map_err(ApiError::NotFound)?;
     let new_timeline_info = async {
-        match tenant.create_timeline(
-            request_data.new_timeline_id.map(TimelineId::from),
-            request_data.ancestor_timeline_id.map(TimelineId::from),
-            request_data.ancestor_start_lsn,
-            request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
-            request_data.region_id.unwrap_or_default(),
-        ).await {
+        match tenant
+            .create_timeline(
+                request_data.new_timeline_id.map(TimelineId::from),
+                request_data.ancestor_timeline_id.map(TimelineId::from),
+                request_data.ancestor_start_lsn,
+                request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
+                request_data.region_id.unwrap_or_default(),
+            )
+            .await
+        {
             Ok(Some(new_timeline)) => {
                 // Created. Construct a TimelineInfo for it.
                 let timeline_info = build_timeline_info(state, &new_timeline, false, false)
@@ -214,7 +217,7 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
                                               lsn=?request_data.ancestor_start_lsn,
                                               pg_version=?request_data.pg_version,
                                               region_id=?request_data.region_id))
-        .await?;
+    .await?;
 
     Ok(match new_timeline_info {
         Some(info) => json_response(StatusCode::CREATED, info)?,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -552,7 +552,7 @@ impl PageServerHandler {
         Ok(lsn)
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, req_lsn = %req.lsn))]
     async fn handle_get_rel_exists_request(
         &self,
         timeline: &Timeline,
@@ -570,7 +570,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, req_lsn = %req.lsn))]
     async fn handle_get_nblocks_request(
         &self,
         timeline: &Timeline,
@@ -588,7 +588,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(dbnode = %req.dbnode, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, dbnode = %req.dbnode, req_lsn = %req.lsn))]
     async fn handle_db_size_request(
         &self,
         timeline: &Timeline,
@@ -609,7 +609,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn))]
     async fn handle_get_page_at_lsn_request(
         &self,
         timeline: &Timeline,
@@ -639,7 +639,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(slru_kind = %req.kind.to_str(), segno = %req.segno,
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, slru_kind = %req.kind.to_str(), segno = %req.segno,
                  check_blkno = %req.blkno, req_lsn = %req.lsn, check_exists_only = %req.check_exists_only))]
     async fn handle_get_slru_page_at_lsn_request(
         &self,


### PR DESCRIPTION
Size of a remote relation may be changed by a remote region so the cache may get outdated.