### PR TITLE
Make github workflows work using public resources

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,8 +18,7 @@ env:
 
 jobs:
   tag:
-    runs-on: dev
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:latest
+    runs-on: ubuntu-latest
     outputs:
       build-tag: ${{steps.build-tag.outputs.tag}}
 
@@ -46,10 +45,11 @@ jobs:
         id: build-tag
 
   build-neon:
-    runs-on: dev
+    runs-on: ubuntu-latest
+    # (Remotexact) use the public rust image and set user to nonroot
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
+      image: neondatabase/rust:pinned
+      options: --init --user root
     strategy:
       fail-fast: false
       matrix:
@@ -144,323 +144,329 @@ jobs:
           path: pg_install/v15
           key: v1-${{ runner.os }}-${{ matrix.build_type }}-pg-${{ steps.pg_v15_rev.outputs.pg_rev }}-${{ hashFiles('Makefile') }}
 
+      # (Remotexact) the user in the rust image is "nonroot". Transfer the ownership of
+      #              the repo so that nonroot can work on it later on
+      - name: Transfer ownership to nonroot
+        run: chown -R nonroot:nonroot .
+
+      # (Remotexact) need "nonroot" to build and test because some tests need to call
+      #              initdb of Postgres, which does not allow calling as root
+
       - name: Build postgres v14
         if: steps.cache_pg_14.outputs.cache-hit != 'true'
-        run: mold -run make postgres-v14 -j$(nproc)
+        run: su nonroot -c "mold -run make postgres-v14 -j$(nproc)"
         shell: bash -euxo pipefail {0}
 
       - name: Build postgres v15
         if: steps.cache_pg_15.outputs.cache-hit != 'true'
-        run: mold -run make postgres-v15 -j$(nproc)
+        run: su nonroot -c "mold -run make postgres-v15 -j$(nproc)"
         shell: bash -euxo pipefail {0}
 
       - name: Build neon extensions
-        run: mold -run make neon-pg-ext -j$(nproc)
+        run: su nonroot -c "mold -run make neon-pg-ext -j$(nproc)"
         shell: bash -euxo pipefail {0}
 
       - name: Run cargo build
-        run: |
-          ${cov_prefix} mold -run cargo build $CARGO_FLAGS --bins --tests
+        run: su nonroot -c "${cov_prefix} mold -run cargo build $CARGO_FLAGS --bins --tests"
         shell: bash -euxo pipefail {0}
 
       - name: Run cargo test
-        run: |
-          ${cov_prefix} cargo test $CARGO_FLAGS
+        run: su nonroot -c "${cov_prefix} cargo test $CARGO_FLAGS"
         shell: bash -euxo pipefail {0}
 
-      - name: Install rust binaries
-        run: |
-          # Install target binaries
-          mkdir -p /tmp/neon/bin/
-          binaries=$(
-            ${cov_prefix} cargo metadata $CARGO_FEATURES --format-version=1 --no-deps |
-            jq -r '.packages[].targets[] | select(.kind | index("bin")) | .name'
-          )
-          for bin in $binaries; do
-            SRC=target/$BUILD_TYPE/$bin
-            DST=/tmp/neon/bin/$bin
-            cp "$SRC" "$DST"
-          done
+      # - name: Install rust binaries
+      #   run: |
+      #     # Install target binaries
+      #     mkdir -p /tmp/neon/bin/
+      #     binaries=$(
+      #       ${cov_prefix} cargo metadata $CARGO_FEATURES --format-version=1 --no-deps |
+      #       jq -r '.packages[].targets[] | select(.kind | index("bin")) | .name'
+      #     )
+      #     for bin in $binaries; do
+      #       SRC=target/$BUILD_TYPE/$bin
+      #       DST=/tmp/neon/bin/$bin
+      #       cp "$SRC" "$DST"
+      #     done
 
-          # Install test executables and write list of all binaries (for code coverage)
-          if [[ $BUILD_TYPE == "debug" ]]; then
-            # Keep bloated coverage data files away from the rest of the artifact
-            mkdir -p /tmp/coverage/
+      #     # Install test executables and write list of all binaries (for code coverage)
+      #     if [[ $BUILD_TYPE == "debug" ]]; then
+      #       # Keep bloated coverage data files away from the rest of the artifact
+      #       mkdir -p /tmp/coverage/
 
-            mkdir -p /tmp/neon/test_bin/
+      #       mkdir -p /tmp/neon/test_bin/
 
-            test_exe_paths=$(
-              ${cov_prefix} cargo test $CARGO_FLAGS --message-format=json --no-run |
-              jq -r '.executable | select(. != null)'
-            )
-            for bin in $test_exe_paths; do
-              SRC=$bin
-              DST=/tmp/neon/test_bin/$(basename $bin)
+      #       test_exe_paths=$(
+      #         ${cov_prefix} cargo test $CARGO_FLAGS --message-format=json --no-run |
+      #         jq -r '.executable | select(. != null)'
+      #       )
+      #       for bin in $test_exe_paths; do
+      #         SRC=$bin
+      #         DST=/tmp/neon/test_bin/$(basename $bin)
 
-              # We don't need debug symbols for code coverage, so strip them out to make
-              # the artifact smaller.
-              strip "$SRC" -o "$DST"
-              echo "$DST" >> /tmp/coverage/binaries.list
-            done
+      #         # We don't need debug symbols for code coverage, so strip them out to make
+      #         # the artifact smaller.
+      #         strip "$SRC" -o "$DST"
+      #         echo "$DST" >> /tmp/coverage/binaries.list
+      #       done
 
-            for bin in $binaries; do
-              echo "/tmp/neon/bin/$bin" >> /tmp/coverage/binaries.list
-            done
-          fi
-        shell: bash -euxo pipefail {0}
+      #       for bin in $binaries; do
+      #         echo "/tmp/neon/bin/$bin" >> /tmp/coverage/binaries.list
+      #       done
+      #     fi
+      #   shell: bash -euxo pipefail {0}
 
-      - name: Install postgres binaries
-        run: cp -a pg_install /tmp/neon/pg_install
-        shell: bash -euxo pipefail {0}
+      # - name: Install postgres binaries
+      #   run: cp -a pg_install /tmp/neon/pg_install
+      #   shell: bash -euxo pipefail {0}
 
-      - name: Upload Neon artifact
-        uses: ./.github/actions/upload
-        with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
-          path: /tmp/neon
+      # - name: Upload Neon artifact
+      #   uses: ./.github/actions/upload
+      #   with:
+      #     name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
+      #     path: /tmp/neon
 
-      - name: Prepare cargo build timing stats for storing
-        run: |
-          mkdir -p "/tmp/neon/cargo-timings/$BUILD_TYPE/"
-          cp -r ./target/cargo-timings/* "/tmp/neon/cargo-timings/$BUILD_TYPE/"
-        shell: bash -euxo pipefail {0}
-      - name: Upload cargo build stats
-        uses: ./.github/actions/upload
-        with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-build-stats
-          path: /tmp/neon/cargo-timings/
+      # - name: Prepare cargo build timing stats for storing
+      #   run: |
+      #     mkdir -p "/tmp/neon/cargo-timings/$BUILD_TYPE/"
+      #     cp -r ./target/cargo-timings/* "/tmp/neon/cargo-timings/$BUILD_TYPE/"
+      #   shell: bash -euxo pipefail {0}
+      # - name: Upload cargo build stats
+      #   uses: ./.github/actions/upload
+      #   with:
+      #     name: neon-${{ runner.os }}-${{ matrix.build_type }}-build-stats
+      #     path: /tmp/neon/cargo-timings/
 
       # XXX: keep this after the binaries.list is formed, so the coverage can properly work later
-      - name: Merge and upload coverage data
-        if: matrix.build_type == 'debug'
-        uses: ./.github/actions/save-coverage-data
+      # - name: Merge and upload coverage data
+      #   if: matrix.build_type == 'debug'
+      #   uses: ./.github/actions/save-coverage-data
 
-  regress-tests:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
-    needs: [ build-neon ]
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [ debug, release ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 2
+  # regress-tests:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
+  #   needs: [ build-neon ]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       build_type: [ debug, release ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 2
 
-      - name: Pytest regression tests
-        uses: ./.github/actions/run-python-test-set
-        with:
-          build_type: ${{ matrix.build_type }}
-          test_selection: regress
-          needs_postgres_source: true
-          run_with_real_s3: true
-          real_s3_bucket: ci-tests-s3
-          real_s3_region: us-west-2
-          real_s3_access_key_id: "${{ secrets.AWS_ACCESS_KEY_ID_CI_TESTS_S3 }}"
-          real_s3_secret_access_key: "${{ secrets.AWS_SECRET_ACCESS_KEY_CI_TESTS_S3 }}"
+  #     - name: Pytest regression tests
+  #       uses: ./.github/actions/run-python-test-set
+  #       with:
+  #         build_type: ${{ matrix.build_type }}
+  #         test_selection: regress
+  #         needs_postgres_source: true
+  #         run_with_real_s3: true
+  #         real_s3_bucket: ci-tests-s3
+  #         real_s3_region: us-west-2
+  #         real_s3_access_key_id: "${{ secrets.AWS_ACCESS_KEY_ID_CI_TESTS_S3 }}"
+  #         real_s3_secret_access_key: "${{ secrets.AWS_SECRET_ACCESS_KEY_CI_TESTS_S3 }}"
 
-      - name: Merge and upload coverage data
-        if: matrix.build_type == 'debug'
-        uses: ./.github/actions/save-coverage-data
+  #     - name: Merge and upload coverage data
+  #       if: matrix.build_type == 'debug'
+  #       uses: ./.github/actions/save-coverage-data
 
-  benchmarks:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
-    needs: [ build-neon ]
-    if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [ release ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 2
+  # benchmarks:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
+  #   needs: [ build-neon ]
+  #   if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       build_type: [ release ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 2
 
-      - name: Pytest benchmarks
-        uses: ./.github/actions/run-python-test-set
-        with:
-          build_type: ${{ matrix.build_type }}
-          test_selection: performance
-          run_in_parallel: false
-          save_perf_report: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
-          PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
-      # XXX: no coverage data handling here, since benchmarks are run on release builds,
-      # while coverage is currently collected for the debug ones
+  #     - name: Pytest benchmarks
+  #       uses: ./.github/actions/run-python-test-set
+  #       with:
+  #         build_type: ${{ matrix.build_type }}
+  #         test_selection: performance
+  #         run_in_parallel: false
+  #         save_perf_report: ${{ github.ref == 'refs/heads/main' }}
+  #       env:
+  #         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
+  #         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
+  #     # XXX: no coverage data handling here, since benchmarks are run on release builds,
+  #     # while coverage is currently collected for the debug ones
 
-  merge-allure-report:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
-    needs: [ regress-tests, benchmarks ]
-    if: always()
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [ debug, release ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: false
+  # merge-allure-report:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
+  #   needs: [ regress-tests, benchmarks ]
+  #   if: always()
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       build_type: [ debug, release ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: false
 
-      - name: Create Allure report
-        id: create-allure-report
-        uses: ./.github/actions/allure-report
-        with:
-          action: generate
-          build_type: ${{ matrix.build_type }}
+  #     - name: Create Allure report
+  #       id: create-allure-report
+  #       uses: ./.github/actions/allure-report
+  #       with:
+  #         action: generate
+  #         build_type: ${{ matrix.build_type }}
 
-      - name: Store Allure test stat in the DB
-        if: ${{ steps.create-allure-report.outputs.report-url }}
-        env:
-          BUILD_TYPE: ${{ matrix.build_type }}
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          REPORT_URL: ${{ steps.create-allure-report.outputs.report-url }}
-          TEST_RESULT_CONNSTR: ${{ secrets.REGRESS_TEST_RESULT_CONNSTR }}
-        shell: bash -euxo pipefail {0}
-        run: |
-          curl --fail --output suites.json ${REPORT_URL%/index.html}/data/suites.json
-          ./scripts/pysync
+  #     - name: Store Allure test stat in the DB
+  #       if: ${{ steps.create-allure-report.outputs.report-url }}
+  #       env:
+  #         BUILD_TYPE: ${{ matrix.build_type }}
+  #         SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  #         REPORT_URL: ${{ steps.create-allure-report.outputs.report-url }}
+  #         TEST_RESULT_CONNSTR: ${{ secrets.REGRESS_TEST_RESULT_CONNSTR }}
+  #       shell: bash -euxo pipefail {0}
+  #       run: |
+  #         curl --fail --output suites.json ${REPORT_URL%/index.html}/data/suites.json
+  #         ./scripts/pysync
 
-          DATABASE_URL="$TEST_RESULT_CONNSTR" poetry run python3 scripts/ingest_regress_test_result.py --revision ${SHA} --reference ${GITHUB_REF} --build-type ${BUILD_TYPE} --ingest suites.json
+  #         DATABASE_URL="$TEST_RESULT_CONNSTR" poetry run python3 scripts/ingest_regress_test_result.py --revision ${SHA} --reference ${GITHUB_REF} --build-type ${BUILD_TYPE} --ingest suites.json
 
-  coverage-report:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
-    needs: [ regress-tests ]
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [ debug ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 1
+  # coverage-report:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
+  #   needs: [ regress-tests ]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       build_type: [ debug ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 1
 
-      - name: Restore cargo deps cache
-        id: cache_cargo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/
-            !~/.cargo/registry/src
-            ~/.cargo/git/
-            target/
-          key: v10-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ hashFiles('Cargo.lock') }}
+  #     - name: Restore cargo deps cache
+  #       id: cache_cargo
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry/
+  #           !~/.cargo/registry/src
+  #           ~/.cargo/git/
+  #           target/
+  #         key: v10-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ hashFiles('Cargo.lock') }}
 
-      - name: Get Neon artifact
-        uses: ./.github/actions/download
-        with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
-          path: /tmp/neon
+  #     - name: Get Neon artifact
+  #       uses: ./.github/actions/download
+  #       with:
+  #         name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
+  #         path: /tmp/neon
 
-      - name: Get coverage artifact
-        uses: ./.github/actions/download
-        with:
-          name: coverage-data-artifact
-          path: /tmp/coverage
+  #     - name: Get coverage artifact
+  #       uses: ./.github/actions/download
+  #       with:
+  #         name: coverage-data-artifact
+  #         path: /tmp/coverage
 
-      - name: Merge coverage data
-        run: scripts/coverage "--profraw-prefix=$GITHUB_JOB" --dir=/tmp/coverage merge
-        shell: bash -euxo pipefail {0}
+  #     - name: Merge coverage data
+  #       run: scripts/coverage "--profraw-prefix=$GITHUB_JOB" --dir=/tmp/coverage merge
+  #       shell: bash -euxo pipefail {0}
 
-      - name: Build and upload coverage report
-        run: |
-          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
-          COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
-          COMMIT_URL=https://github.com/${{ github.repository }}/commit/$COMMIT_SHA
+  #     - name: Build and upload coverage report
+  #       run: |
+  #         COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+  #         COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
+  #         COMMIT_URL=https://github.com/${{ github.repository }}/commit/$COMMIT_SHA
 
-          scripts/coverage \
-            --dir=/tmp/coverage report \
-            --input-objects=/tmp/coverage/binaries.list \
-            --commit-url=$COMMIT_URL \
-            --format=github
+  #         scripts/coverage \
+  #           --dir=/tmp/coverage report \
+  #           --input-objects=/tmp/coverage/binaries.list \
+  #           --commit-url=$COMMIT_URL \
+  #           --format=github
 
-          REPORT_URL=https://${{ github.repository_owner }}.github.io/zenith-coverage-data/$COMMIT_SHA
+  #         REPORT_URL=https://${{ github.repository_owner }}.github.io/zenith-coverage-data/$COMMIT_SHA
 
-          scripts/git-upload \
-            --repo=https://${{ secrets.VIP_VAP_ACCESS_TOKEN }}@github.com/${{ github.repository_owner }}/zenith-coverage-data.git \
-            --message="Add code coverage for $COMMIT_URL" \
-            copy /tmp/coverage/report $COMMIT_SHA # COPY FROM TO_RELATIVE
+  #         scripts/git-upload \
+  #           --repo=https://${{ secrets.VIP_VAP_ACCESS_TOKEN }}@github.com/${{ github.repository_owner }}/zenith-coverage-data.git \
+  #           --message="Add code coverage for $COMMIT_URL" \
+  #           copy /tmp/coverage/report $COMMIT_SHA # COPY FROM TO_RELATIVE
 
-          # Add link to the coverage report to the commit
-          curl -f -X POST \
-          https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
-          -H "Accept: application/vnd.github.v3+json" \
-          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
-          --data \
-            "{
-              \"state\": \"success\",
-              \"context\": \"neon-coverage\",
-              \"description\": \"Coverage report is ready\",
-              \"target_url\": \"$REPORT_URL\"
-            }"
-        shell: bash -euxo pipefail {0}
+  #         # Add link to the coverage report to the commit
+  #         curl -f -X POST \
+  #         https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
+  #         -H "Accept: application/vnd.github.v3+json" \
+  #         --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+  #         --data \
+  #           "{
+  #             \"state\": \"success\",
+  #             \"context\": \"neon-coverage\",
+  #             \"description\": \"Coverage report is ready\",
+  #             \"target_url\": \"$REPORT_URL\"
+  #           }"
+  #       shell: bash -euxo pipefail {0}
 
-  trigger-e2e-tests:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
-      options: --init
-    needs: [ push-docker-hub, tag ]
-    steps:
-      - name: Set PR's status to pending and request a remote CI test
-        run: |
-          # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
-          # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,
-          # to place a job run status update later.
-          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
-          # For non-PR kinds of runs, the above will produce an empty variable, pick the original sha value for those
-          COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
+  # trigger-e2e-tests:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
+  #     options: --init
+  #   needs: [ push-docker-hub, tag ]
+  #   steps:
+  #     - name: Set PR's status to pending and request a remote CI test
+  #       run: |
+  #         # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
+  #         # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,
+  #         # to place a job run status update later.
+  #         COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+  #         # For non-PR kinds of runs, the above will produce an empty variable, pick the original sha value for those
+  #         COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
 
-          REMOTE_REPO="${{ github.repository_owner }}/cloud"
+  #         REMOTE_REPO="${{ github.repository_owner }}/cloud"
 
-          curl -f -X POST \
-          https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
-          -H "Accept: application/vnd.github.v3+json" \
-          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
-          --data \
-            "{
-              \"state\": \"pending\",
-              \"context\": \"neon-cloud-e2e\",
-              \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
-            }"
+  #         curl -f -X POST \
+  #         https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
+  #         -H "Accept: application/vnd.github.v3+json" \
+  #         --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+  #         --data \
+  #           "{
+  #             \"state\": \"pending\",
+  #             \"context\": \"neon-cloud-e2e\",
+  #             \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
+  #           }"
 
-          curl -f -X POST \
-          https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
-          -H "Accept: application/vnd.github.v3+json" \
-          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
-          --data \
-            "{
-              \"ref\": \"main\",
-              \"inputs\": {
-                \"ci_job_name\": \"neon-cloud-e2e\",
-                \"commit_hash\": \"$COMMIT_SHA\",
-                \"remote_repo\": \"${{ github.repository }}\",
-                \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\"
-              }
-            }"
+  #         curl -f -X POST \
+  #         https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
+  #         -H "Accept: application/vnd.github.v3+json" \
+  #         --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+  #         --data \
+  #           "{
+  #             \"ref\": \"main\",
+  #             \"inputs\": {
+  #               \"ci_job_name\": \"neon-cloud-e2e\",
+  #               \"commit_hash\": \"$COMMIT_SHA\",
+  #               \"remote_repo\": \"${{ github.repository }}\",
+  #               \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
+  #               \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\"
+  #             }
+  #           }"
 
   neon-image:
-    runs-on: dev
+    runs-on: ubuntu-latest
     needs: [ tag ]
     container: gcr.io/kaniko-project/executor:v1.9.0-debug
 
@@ -471,14 +477,15 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Configure ECR login
-        run: echo "{\"credsStore\":\"ecr-login\"}" > /kaniko/.docker/config.json
+      # (Remotexact) Push directly to Docker Hub
+      - name: Configure Docker Hub login
+        run: echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${{secrets.DOCKERHUB_CRED_BASE64}}\"}}}" > /kaniko/.docker/config.json
 
       - name: Kaniko build neon
-        run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache --snapshotMode=redo --context . --build-arg GIT_VERSION=${{ github.sha }} --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}}
+        run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo ctring/neon-cache --snapshotMode=redo --context . --build-arg GIT_VERSION=${{ github.sha }} --destination ctring/neon:${{needs.tag.outputs.build-tag}}
 
   compute-tools-image:
-    runs-on: dev
+    runs-on: ubuntu-latest
     needs: [ tag ]
     container: gcr.io/kaniko-project/executor:v1.9.0-debug
 
@@ -486,14 +493,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1 # v3 won't work with kaniko
 
-      - name: Configure ECR login
-        run: echo "{\"credsStore\":\"ecr-login\"}" > /kaniko/.docker/config.json
+      # (Remotexact) Push directly to Docker Hub
+      - name: Configure Docker Hub login
+        run: echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${{secrets.DOCKERHUB_CRED_BASE64}}\"}}}" > /kaniko/.docker/config.json
 
       - name: Kaniko build compute tools
-        run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache --snapshotMode=redo --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-tools --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:${{needs.tag.outputs.build-tag}}
+        run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo ctring/neon-cache --snapshotMode=redo --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-tools --destination ctring/compute-tools:${{needs.tag.outputs.build-tag}}
 
   compute-node-image-v14:
-    runs-on: dev
+    runs-on: ubuntu-latest
     container: gcr.io/kaniko-project/executor:v1.9.0-debug
     needs: [ tag ]
     steps:
@@ -503,14 +511,15 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Configure ECR login
-        run: echo "{\"credsStore\":\"ecr-login\"}" > /kaniko/.docker/config.json
+      # (Remotexact) Push directly to Docker Hub
+      - name: Configure Docker Hub login
+        run: echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${{secrets.DOCKERHUB_CRED_BASE64}}\"}}}" > /kaniko/.docker/config.json
 
       - name: Kaniko build compute node with extensions v14
-        run: /kaniko/executor --skip-unused-stages  --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache  --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-node-v14 --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:${{needs.tag.outputs.build-tag}}
+        run: /kaniko/executor --skip-unused-stages  --snapshotMode=redo --cache=true --cache-repo ctring/neon-cache  --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-node-v14 --destination ctring/compute-node-v14:${{needs.tag.outputs.build-tag}}
 
   compute-node-image-v15:
-    runs-on: dev
+    runs-on: ubuntu-latest
     container: gcr.io/kaniko-project/executor:v1.9.0-debug
     needs: [ tag ]
     steps:
@@ -520,15 +529,16 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Configure ECR login
-        run: echo "{\"credsStore\":\"ecr-login\"}" > /kaniko/.docker/config.json
+      # (Remotexact) Push directly to Docker Hub
+      - name: Configure Docker Hub login
+        run: echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${{secrets.DOCKERHUB_CRED_BASE64}}\"}}}" > /kaniko/.docker/config.json
 
       - name: Kaniko build compute node with extensions v15
-        run: /kaniko/executor --skip-unused-stages --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-node-v15 --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}}
+        run: /kaniko/executor --skip-unused-stages --snapshotMode=redo --cache=true --cache-repo ctring/neon-cache --context . --build-arg GIT_VERSION=${{ github.sha }} --dockerfile Dockerfile.compute-node-v15 --destination ctring/compute-node-v15:${{needs.tag.outputs.build-tag}}
 
   test-images:
     needs: [ tag, neon-image, compute-node-image-v14, compute-node-image-v15, compute-tools-image ]
-    runs-on: dev
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -546,7 +556,7 @@ jobs:
       - name: Verify image versions
         shell: bash # ensure no set -e for better error messages
         run: |
-          pageserver_version=$(docker run --rm 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} "/bin/sh" "-c" "/usr/local/bin/pageserver --version")
+          pageserver_version=$(docker run --rm ctring/neon:${{needs.tag.outputs.build-tag}} "/bin/sh" "-c" "/usr/local/bin/pageserver --version")
 
           echo "Pageserver version string: $pageserver_version"
 
@@ -561,7 +571,8 @@ jobs:
           fi
 
       - name: Verify docker-compose example
-        run: env REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com TAG=${{needs.tag.outputs.build-tag}} ./docker-compose/docker_compose_test.sh
+        # (Remotexact) Use 'ctring' for REPOSITORY
+        run: env REPOSITORY=ctring TAG=${{needs.tag.outputs.build-tag}} ./docker-compose/docker_compose_test.sh
 
       - name: Print logs and clean up
         if: always()
@@ -569,396 +580,396 @@ jobs:
           docker compose -f ./docker-compose/docker-compose.yml logs || 0
           docker compose -f ./docker-compose/docker-compose.yml down
 
-  promote-images:
-    runs-on: dev
-    needs: [ tag, test-images ]
-    if: github.event_name != 'workflow_dispatch'
-    container: amazon/aws-cli
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [ neon, compute-node-v14, compute-node-v15, compute-tools ]
+  # promote-images:
+  #   runs-on: ubuntu-latest
+  #   needs: [ tag, test-images ]
+  #   if: github.event_name != 'workflow_dispatch'
+  #   container: amazon/aws-cli
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       name: [ neon, compute-node-v14, compute-node-v15, compute-tools ]
 
-    steps:
-      - name: Promote image to latest
-        run: |
-          export MANIFEST=$(aws ecr batch-get-image --repository-name ${{ matrix.name }} --image-ids imageTag=${{needs.tag.outputs.build-tag}} --query 'images[].imageManifest' --output text)
-          aws ecr put-image --repository-name ${{ matrix.name }} --image-tag latest --image-manifest "$MANIFEST"
-
+  #   steps:
+  #     - name: Promote image to latest
+  #       run: |
+  #         export MANIFEST=$(aws ecr batch-get-image --repository-name ${{ matrix.name }} --image-ids imageTag=${{needs.tag.outputs.build-tag}} --query 'images[].imageManifest' --output text)
+  #         aws ecr put-image --repository-name ${{ matrix.name }} --image-tag latest --image-manifest "$MANIFEST"
+  
+  # (Remotexact) We use this job to retag the images to 'latest'
   push-docker-hub:
-    runs-on: dev
-    needs: [ promote-images, tag ]
+    runs-on: ubuntu-latest
+    # needs: [ promote-images, tag ]
+    needs: [ tag, test-images ]
     container: golang:1.19-bullseye
 
     steps:
       - name: Install Crane & ECR helper
         run: |
           go install github.com/google/go-containerregistry/cmd/crane@31786c6cbb82d6ec4fb8eb79cd9387905130534e # v0.11.0
-          go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f # v0.6.0
+          # go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f # v0.6.0
 
-      - name: Configure ECR login
-        run: |
-          mkdir /github/home/.docker/
-          echo "{\"credsStore\":\"ecr-login\"}" > /github/home/.docker/config.json
+      # - name: Configure ECR login
+      #   run: |
+      #     mkdir /github/home/.docker/
+      #     echo "{\"credsStore\":\"ecr-login\"}" > /github/home/.docker/config.json
 
-      - name: Pull neon image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} neon
+      - name: Pull neon image from Docker Hub
+        run: crane pull ctring/neon:${{needs.tag.outputs.build-tag}} neon
 
-      - name: Pull compute tools image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:${{needs.tag.outputs.build-tag}} compute-tools
+      - name: Pull compute tools image from Docker Hub
+        run: crane pull ctring/compute-tools:${{needs.tag.outputs.build-tag}} compute-tools
 
-      - name: Pull compute node v14 image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:${{needs.tag.outputs.build-tag}} compute-node-v14
+      - name: Pull compute node v14 image from Docker Hub
+        run: crane pull ctring/compute-node-v14:${{needs.tag.outputs.build-tag}} compute-node-v14
 
-      - name: Pull compute node v15 image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} compute-node-v15
+      - name: Pull compute node v15 image from Docker Hub
+        run: crane pull ctring/compute-node-v15:${{needs.tag.outputs.build-tag}} compute-node-v15
 
-      - name: Pull rust image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned rust
+      # - name: Pull rust image from ECR
+      #   run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned rust
 
-      - name: Push images to production ECR
-        if: |
-          (github.ref_name == 'main' || github.ref_name == 'release') &&
-          github.event_name != 'workflow_dispatch'
-        run: |
-          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/neon:latest
-          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:latest
-          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:latest
-          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:latest
+      # - name: Push images to production ECR
+      #   if: |
+      #     (github.ref_name == 'main' || github.ref_name == 'release') &&
+      #     github.event_name != 'workflow_dispatch'
+      #   run: |
+      #     crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/neon:latest
+      #     crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:latest
+      #     crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:latest
+      #     crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:latest
 
       - name: Configure Docker Hub login
         run: |
-          # ECR Credential Helper & Docker Hub don't work together in config, hence reset
-          echo "" > /github/home/.docker/config.json
-          crane auth login -u ${{ secrets.NEON_DOCKERHUB_USERNAME }} -p ${{ secrets.NEON_DOCKERHUB_PASSWORD }} index.docker.io
+          crane auth login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }} index.docker.io
 
-      - name: Push neon image to Docker Hub
-        run: crane push neon neondatabase/neon:${{needs.tag.outputs.build-tag}}
+      # - name: Push neon image to Docker Hub
+      #   run: crane push neon neondatabase/neon:${{needs.tag.outputs.build-tag}}
 
-      - name: Push compute tools image to Docker Hub
-        run: crane push compute-tools neondatabase/compute-tools:${{needs.tag.outputs.build-tag}}
+      # - name: Push compute tools image to Docker Hub
+      #   run: crane push compute-tools neondatabase/compute-tools:${{needs.tag.outputs.build-tag}}
 
-      - name: Push compute node v14 image to Docker Hub
-        run: crane push compute-node-v14 neondatabase/compute-node-v14:${{needs.tag.outputs.build-tag}}
+      # - name: Push compute node v14 image to Docker Hub
+      #   run: crane push compute-node-v14 neondatabase/compute-node-v14:${{needs.tag.outputs.build-tag}}
 
-      - name: Push compute node v15 image to Docker Hub
-        run: crane push compute-node-v15 neondatabase/compute-node-v15:${{needs.tag.outputs.build-tag}}
+      # - name: Push compute node v15 image to Docker Hub
+      #   run: crane push compute-node-v15 neondatabase/compute-node-v15:${{needs.tag.outputs.build-tag}}
 
-      - name: Push rust image to Docker Hub
-        run: crane push rust neondatabase/rust:pinned
+      # - name: Push rust image to Docker Hub
+      #   run: crane push rust neondatabase/rust:pinned
 
       - name: Add latest tag to images in Docker Hub
         if: |
-          (github.ref_name == 'main' || github.ref_name == 'release') &&
+          (github.ref_name == 'remotexact' || github.ref_name == 'release') &&
           github.event_name != 'workflow_dispatch'
         run: |
-          crane tag neondatabase/neon:${{needs.tag.outputs.build-tag}} latest
-          crane tag neondatabase/compute-tools:${{needs.tag.outputs.build-tag}} latest
-          crane tag neondatabase/compute-node-v14:${{needs.tag.outputs.build-tag}} latest
-          crane tag neondatabase/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
+          crane tag ctring/neon:${{needs.tag.outputs.build-tag}} latest
+          crane tag ctring/compute-tools:${{needs.tag.outputs.build-tag}} latest
+          crane tag ctring/compute-node-v14:${{needs.tag.outputs.build-tag}} latest
+          crane tag ctring/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
 
-  calculate-deploy-targets:
-    runs-on: [ self-hosted, Linux, k8s-runner ]
-    if: |
-      (github.ref_name == 'main' || github.ref_name == 'release') &&
-      github.event_name != 'workflow_dispatch'
-    outputs:
-      matrix-include: ${{ steps.set-matrix.outputs.include }}
-    steps:
-      - id: set-matrix
-        run: |
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            STAGING='{"env_name": "staging", "proxy_job": "neon-proxy", "proxy_config": "staging.proxy", "kubeconfig_secret": "STAGING_KUBECONFIG_DATA", "console_api_key_secret": "NEON_STAGING_API_KEY"}'
-            NEON_STRESS='{"env_name": "neon-stress", "proxy_job": "neon-stress-proxy", "proxy_config": "neon-stress.proxy", "kubeconfig_secret": "NEON_STRESS_KUBECONFIG_DATA", "console_api_key_secret": "NEON_CAPTEST_API_KEY"}'
-            echo "include=[$STAGING, $NEON_STRESS]" >> $GITHUB_OUTPUT
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            PRODUCTION='{"env_name": "production", "proxy_job": "neon-proxy", "proxy_config": "production.proxy", "kubeconfig_secret": "PRODUCTION_KUBECONFIG_DATA", "console_api_key_secret": "NEON_PRODUCTION_API_KEY"}'
-            echo "include=[$PRODUCTION]" >> $GITHUB_OUTPUT
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
+  # calculate-deploy-targets:
+  #   runs-on: [ self-hosted, Linux, k8s-runner ]
+  #   if: |
+  #     (github.ref_name == 'main' || github.ref_name == 'release') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   outputs:
+  #     matrix-include: ${{ steps.set-matrix.outputs.include }}
+  #   steps:
+  #     - id: set-matrix
+  #       run: |
+  #         if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+  #           STAGING='{"env_name": "staging", "proxy_job": "neon-proxy", "proxy_config": "staging.proxy", "kubeconfig_secret": "STAGING_KUBECONFIG_DATA", "console_api_key_secret": "NEON_STAGING_API_KEY"}'
+  #           NEON_STRESS='{"env_name": "neon-stress", "proxy_job": "neon-stress-proxy", "proxy_config": "neon-stress.proxy", "kubeconfig_secret": "NEON_STRESS_KUBECONFIG_DATA", "console_api_key_secret": "NEON_CAPTEST_API_KEY"}'
+  #           echo "include=[$STAGING, $NEON_STRESS]" >> $GITHUB_OUTPUT
+  #         elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
+  #           PRODUCTION='{"env_name": "production", "proxy_job": "neon-proxy", "proxy_config": "production.proxy", "kubeconfig_secret": "PRODUCTION_KUBECONFIG_DATA", "console_api_key_secret": "NEON_PRODUCTION_API_KEY"}'
+  #           echo "include=[$PRODUCTION]" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
+  #           exit 1
+  #         fi
 
-  deploy:
-    runs-on: [ self-hosted, Linux, k8s-runner ]
-    #container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:latest
-    # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
-    # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'main' || github.ref_name == 'release') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        include: ${{fromJSON(needs.calculate-deploy-targets.outputs.matrix-include)}}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy:
+  #   runs-on: [ self-hosted, Linux, k8s-runner ]
+  #   #container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:latest
+  #   # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
+  #   # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'main' || github.ref_name == 'release') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       include: ${{fromJSON(needs.calculate-deploy-targets.outputs.matrix-include)}}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+  #     - name: Setup python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.10'
 
-      - name: Setup ansible
-        run: |
-          export PATH="/root/.local/bin:$PATH"
-          pip install --progress-bar off --user ansible boto3 toml
+  #     - name: Setup ansible
+  #       run: |
+  #         export PATH="/root/.local/bin:$PATH"
+  #         pip install --progress-bar off --user ansible boto3 toml
 
-      - name: Redeploy
-        run: |
-          export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          cd "$(pwd)/.github/ansible"
+  #     - name: Redeploy
+  #       run: |
+  #         export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         cd "$(pwd)/.github/ansible"
 
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            ./get_binaries.sh
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            RELEASE=true ./get_binaries.sh
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
+  #         if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+  #           ./get_binaries.sh
+  #         elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
+  #           RELEASE=true ./get_binaries.sh
+  #         else
+  #           echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
+  #           exit 1
+  #         fi
 
-          eval $(ssh-agent)
-          echo "${{ secrets.TELEPORT_SSH_KEY }}"  | tr -d '\n'| base64 --decode >ssh-key
-          echo "${{ secrets.TELEPORT_SSH_CERT }}" | tr -d '\n'| base64 --decode >ssh-key-cert.pub
-          chmod 0600 ssh-key
-          ssh-add ssh-key
-          rm -f ssh-key ssh-key-cert.pub
-          ansible-galaxy collection install sivel.toiletwater
-          ansible-playbook deploy.yaml -i ${{ matrix.env_name }}.hosts.yaml -e CONSOLE_API_TOKEN=${{ secrets[matrix.console_api_key_secret] }}
-          rm -f neon_install.tar.gz .neon_current_version
+  #         eval $(ssh-agent)
+  #         echo "${{ secrets.TELEPORT_SSH_KEY }}"  | tr -d '\n'| base64 --decode >ssh-key
+  #         echo "${{ secrets.TELEPORT_SSH_CERT }}" | tr -d '\n'| base64 --decode >ssh-key-cert.pub
+  #         chmod 0600 ssh-key
+  #         ssh-add ssh-key
+  #         rm -f ssh-key ssh-key-cert.pub
+  #         ansible-galaxy collection install sivel.toiletwater
+  #         ansible-playbook deploy.yaml -i ${{ matrix.env_name }}.hosts.yaml -e CONSOLE_API_TOKEN=${{ secrets[matrix.console_api_key_secret] }}
+  #         rm -f neon_install.tar.gz .neon_current_version
 
-  deploy-new:
-    runs-on: dev
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:pinned
-    # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
-    # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'main') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        target_region: [ us-east-2 ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy-new:
+  #   runs-on: dev
+  #   container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:pinned
+  #   # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
+  #   # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'main') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       target_region: [ us-east-2 ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Redeploy
-        run: |
-          export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          cd "$(pwd)/.github/ansible"
+  #     - name: Redeploy
+  #       run: |
+  #         export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         cd "$(pwd)/.github/ansible"
 
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            ./get_binaries.sh
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            RELEASE=true ./get_binaries.sh
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
+  #         if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+  #           ./get_binaries.sh
+  #         elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
+  #           RELEASE=true ./get_binaries.sh
+  #         else
+  #           echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
+  #           exit 1
+  #         fi
 
-          ansible-galaxy collection install sivel.toiletwater
-          ansible-playbook deploy.yaml -i staging.${{ matrix.target_region }}.hosts.yaml -e @ssm_config -e CONSOLE_API_TOKEN=${{secrets.NEON_STAGING_API_KEY}}
-          rm -f neon_install.tar.gz .neon_current_version
+  #         ansible-galaxy collection install sivel.toiletwater
+  #         ansible-playbook deploy.yaml -i staging.${{ matrix.target_region }}.hosts.yaml -e @ssm_config -e CONSOLE_API_TOKEN=${{secrets.NEON_STAGING_API_KEY}}
+  #         rm -f neon_install.tar.gz .neon_current_version
 
-  deploy-prod-new:
-    runs-on: prod
-    container: 093970136003.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
-    # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
-    # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'release') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        target_region: [ us-east-2, eu-central-1, ap-southeast-1 ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy-prod-new:
+  #   runs-on: prod
+  #   container: 093970136003.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
+  #   # We need both storage **and** compute images for deploy, because control plane picks the compute version based on the storage version.
+  #   # If it notices a fresh storage it may bump the compute version. And if compute image failed to build it may break things badly
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'release') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       target_region: [ us-east-2, eu-central-1, ap-southeast-1 ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Redeploy
-        run: |
-          export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          cd "$(pwd)/.github/ansible"
+  #     - name: Redeploy
+  #       run: |
+  #         export DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         cd "$(pwd)/.github/ansible"
 
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            ./get_binaries.sh
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            RELEASE=true ./get_binaries.sh
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
+  #         if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+  #           ./get_binaries.sh
+  #         elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
+  #           RELEASE=true ./get_binaries.sh
+  #         else
+  #           echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
+  #           exit 1
+  #         fi
 
-          ansible-galaxy collection install sivel.toiletwater
-          ansible-playbook deploy.yaml -i prod.${{ matrix.target_region }}.hosts.yaml -e @ssm_config -e CONSOLE_API_TOKEN=${{secrets.NEON_PRODUCTION_API_KEY}}
-          rm -f neon_install.tar.gz .neon_current_version
+  #         ansible-galaxy collection install sivel.toiletwater
+  #         ansible-playbook deploy.yaml -i prod.${{ matrix.target_region }}.hosts.yaml -e @ssm_config -e CONSOLE_API_TOKEN=${{secrets.NEON_PRODUCTION_API_KEY}}
+  #         rm -f neon_install.tar.gz .neon_current_version
 
-  deploy-proxy:
-    runs-on: dev
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:latest
-    # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'main' || github.ref_name == 'release') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        include: ${{fromJSON(needs.calculate-deploy-targets.outputs.matrix-include)}}
-    env:
-      KUBECONFIG: .kubeconfig
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy-proxy:
+  #   runs-on: dev
+  #   container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:latest
+  #   # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'main' || github.ref_name == 'release') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       include: ${{fromJSON(needs.calculate-deploy-targets.outputs.matrix-include)}}
+  #   env:
+  #     KUBECONFIG: .kubeconfig
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Add curl
-        run: apt update && apt install curl -y
+  #     - name: Add curl
+  #       run: apt update && apt install curl -y
 
-      - name: Store kubeconfig file
-        run: |
-          echo "${{ secrets[matrix.kubeconfig_secret] }}" | base64 --decode > ${KUBECONFIG}
-          chmod 0600 ${KUBECONFIG}
+  #     - name: Store kubeconfig file
+  #       run: |
+  #         echo "${{ secrets[matrix.kubeconfig_secret] }}" | base64 --decode > ${KUBECONFIG}
+  #         chmod 0600 ${KUBECONFIG}
 
-      - name: Setup helm v3
-        run: |
-          curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          helm repo add neondatabase https://neondatabase.github.io/helm-charts
+  #     - name: Setup helm v3
+  #       run: |
+  #         curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+  #         helm repo add neondatabase https://neondatabase.github.io/helm-charts
 
-      - name: Re-deploy proxy
-        run: |
-          DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          helm upgrade ${{ matrix.proxy_job }}       neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
-          helm upgrade ${{ matrix.proxy_job }}-scram neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+  #     - name: Re-deploy proxy
+  #       run: |
+  #         DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         helm upgrade ${{ matrix.proxy_job }}       neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+  #         helm upgrade ${{ matrix.proxy_job }}-scram neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
 
-  deploy-proxy-new:
-    runs-on: dev
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:pinned
-    # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'main') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        include:
-          - target_region:  us-east-2
-            target_cluster: dev-us-east-2-beta
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy-proxy-new:
+  #   runs-on: dev
+  #   container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:pinned
+  #   # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'main') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - target_region:  us-east-2
+  #           target_cluster: dev-us-east-2-beta
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Configure environment
-        run: |
-          helm repo add neondatabase https://neondatabase.github.io/helm-charts
-          aws --region ${{ matrix.target_region }} eks update-kubeconfig --name  ${{ matrix.target_cluster }}
+  #     - name: Configure environment
+  #       run: |
+  #         helm repo add neondatabase https://neondatabase.github.io/helm-charts
+  #         aws --region ${{ matrix.target_region }} eks update-kubeconfig --name  ${{ matrix.target_cluster }}
 
-      - name: Re-deploy proxy
-        run: |
-          DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          helm upgrade neon-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --create-namespace --install -f .github/helm-values/${{ matrix.target_cluster }}.neon-proxy-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+  #     - name: Re-deploy proxy
+  #       run: |
+  #         DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         helm upgrade neon-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --create-namespace --install -f .github/helm-values/${{ matrix.target_cluster }}.neon-proxy-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
 
-  deploy-proxy-prod-new:
-    runs-on: prod
-    container: 093970136003.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
-    # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
-    needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
-    if: |
-      (github.ref_name == 'release') &&
-      github.event_name != 'workflow_dispatch'
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        include:
-          - target_region:  us-east-2
-            target_cluster: prod-us-east-2-delta
-          - target_region: eu-central-1
-            target_cluster: prod-eu-central-1-gamma
-          - target_region: ap-southeast-1
-            target_cluster: prod-ap-southeast-1-epsilon
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          fetch-depth: 0
+  # deploy-proxy-prod-new:
+  #   runs-on: prod
+  #   container: 093970136003.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
+  #   # Compute image isn't strictly required for proxy deploy, but let's still wait for it to run all deploy jobs consistently.
+  #   needs: [ push-docker-hub, calculate-deploy-targets, tag, regress-tests ]
+  #   if: |
+  #     (github.ref_name == 'release') &&
+  #     github.event_name != 'workflow_dispatch'
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - target_region:  us-east-2
+  #           target_cluster: prod-us-east-2-delta
+  #         - target_region: eu-central-1
+  #           target_cluster: prod-eu-central-1-gamma
+  #         - target_region: ap-southeast-1
+  #           target_cluster: prod-ap-southeast-1-epsilon
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #         fetch-depth: 0
 
-      - name: Configure environment
-        run: |
-          helm repo add neondatabase https://neondatabase.github.io/helm-charts
-          aws --region ${{ matrix.target_region }} eks update-kubeconfig --name  ${{ matrix.target_cluster }}
+  #     - name: Configure environment
+  #       run: |
+  #         helm repo add neondatabase https://neondatabase.github.io/helm-charts
+  #         aws --region ${{ matrix.target_region }} eks update-kubeconfig --name  ${{ matrix.target_cluster }}
 
-      - name: Re-deploy proxy
-        run: |
-          DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          helm upgrade neon-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --create-namespace --install -f .github/helm-values/${{ matrix.target_cluster }}.neon-proxy-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+  #     - name: Re-deploy proxy
+  #       run: |
+  #         DOCKER_TAG=${{needs.tag.outputs.build-tag}}
+  #         helm upgrade neon-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --create-namespace --install -f .github/helm-values/${{ matrix.target_cluster }}.neon-proxy-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
 
-  promote-compatibility-data:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
-    needs: [ deploy, deploy-proxy ]
-    if: github.ref_name == 'release' && github.event_name != 'workflow_dispatch'
-    steps:
-      - name: Promote compatibility snapshot for the release
-        shell: bash -euxo pipefail {0}
-        env:
-          BUCKET: neon-github-public-dev
-          PREFIX: artifacts/latest
-        run: |
-          # Update compatibility snapshot for the release
-          for build_type in debug release; do
-            OLD_FILENAME=compatibility-snapshot-${build_type}-pg14-${GITHUB_RUN_ID}.tar.zst
-            NEW_FILENAME=compatibility-snapshot-${build_type}-pg14.tar.zst
+  # promote-compatibility-data:
+  #   runs-on: dev
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
+  #   needs: [ deploy, deploy-proxy ]
+  #   if: github.ref_name == 'release' && github.event_name != 'workflow_dispatch'
+  #   steps:
+  #     - name: Promote compatibility snapshot for the release
+  #       shell: bash -euxo pipefail {0}
+  #       env:
+  #         BUCKET: neon-github-public-dev
+  #         PREFIX: artifacts/latest
+  #       run: |
+  #         # Update compatibility snapshot for the release
+  #         for build_type in debug release; do
+  #           OLD_FILENAME=compatibility-snapshot-${build_type}-pg14-${GITHUB_RUN_ID}.tar.zst
+  #           NEW_FILENAME=compatibility-snapshot-${build_type}-pg14.tar.zst
 
-            time aws s3 mv --only-show-errors s3://${BUCKET}/${PREFIX}/${OLD_FILENAME} s3://${BUCKET}/${PREFIX}/${NEW_FILENAME}
-          done
+  #           time aws s3 mv --only-show-errors s3://${BUCKET}/${PREFIX}/${OLD_FILENAME} s3://${BUCKET}/${PREFIX}/${NEW_FILENAME}
+  #         done
 
-          # Update Neon artifact for the release (reuse already uploaded artifact)
-          for build_type in debug release; do
-            OLD_PREFIX=artifacts/${GITHUB_RUN_ID}
-            FILENAME=neon-${{ runner.os }}-${build_type}-artifact.tar.zst
+  #         # Update Neon artifact for the release (reuse already uploaded artifact)
+  #         for build_type in debug release; do
+  #           OLD_PREFIX=artifacts/${GITHUB_RUN_ID}
+  #           FILENAME=neon-${{ runner.os }}-${build_type}-artifact.tar.zst
 
-            S3_KEY=$(aws s3api list-objects-v2 --bucket ${BUCKET} --prefix ${OLD_PREFIX} | jq -r '.Contents[].Key' | grep ${FILENAME} | sort --version-sort | tail -1 || true)
-            if [ -z "${S3_KEY}" ]; then
-              echo 2>&1 "Neither s3://${BUCKET}/${OLD_PREFIX}/${FILENAME} nor its version from previous attempts exist"
-              exit 1
-            fi
+  #           S3_KEY=$(aws s3api list-objects-v2 --bucket ${BUCKET} --prefix ${OLD_PREFIX} | jq -r '.Contents[].Key' | grep ${FILENAME} | sort --version-sort | tail -1 || true)
+  #           if [ -z "${S3_KEY}" ]; then
+  #             echo 2>&1 "Neither s3://${BUCKET}/${OLD_PREFIX}/${FILENAME} nor its version from previous attempts exist"
+  #             exit 1
+  #           fi
 
-            time aws s3 cp --only-show-errors s3://${BUCKET}/${S3_KEY} s3://${BUCKET}/${PREFIX}/${FILENAME}
-          done
+  #           time aws s3 cp --only-show-errors s3://${BUCKET}/${S3_KEY} s3://${BUCKET}/${PREFIX}/${FILENAME}
+  #         done

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -114,34 +114,40 @@ jobs:
       - name: Ensure all project builds
         run: cargo build --locked --all --all-targets
 
-  check-rust-dependencies:
-    runs-on: dev
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
-      options: --init
+  # check-rust-dependencies:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+  #     options: --init
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-          fetch-depth: 1
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: false
+  #         fetch-depth: 1
 
-      # https://github.com/facebookincubator/cargo-guppy/tree/bec4e0eb29dcd1faac70b1b5360267fc02bf830e/tools/cargo-hakari#2-keep-the-workspace-hack-up-to-date-in-ci
-      - name: Check every project module is covered by Hakari
-        run: |
-          cargo hakari generate --diff  # workspace-hack Cargo.toml is up-to-date
-          cargo hakari manage-deps --dry-run  # all workspace crates depend on workspace-hack
-        shell: bash -euxo pipefail {0}
+  #     # https://github.com/facebookincubator/cargo-guppy/tree/bec4e0eb29dcd1faac70b1b5360267fc02bf830e/tools/cargo-hakari#2-keep-the-workspace-hack-up-to-date-in-ci
+  #     - name: Check every project module is covered by Hakari
+  #       run: |
+  #         cargo hakari generate --diff  # workspace-hack Cargo.toml is up-to-date
+  #         cargo hakari manage-deps --dry-run  # all workspace crates depend on workspace-hack
+  #       shell: bash -euxo pipefail {0}
 
   check-codestyle-python:
-    runs-on: [ self-hosted, Linux, k8s-runner ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: false
           fetch-depth: 1
+
+      # (Remotexact) ./scripts/pysync requires Python 3.9+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
 
       - name: Cache poetry deps
         id: cache_poetry
@@ -151,7 +157,9 @@ jobs:
           key: v1-codestyle-python-deps-${{ hashFiles('poetry.lock') }}
 
       - name: Install Python deps
-        run: ./scripts/pysync
+        run: |
+          python3 -m pip install poetry
+          ./scripts/pysync
 
       - name: Run isort to ensure code format
         run: poetry run isort --diff --check .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@
 ### The image itself is mainly used as a container for the binaries and for starting e2e tests with custom parameters.
 ### By default, the binaries inside the image have some mock parameters and can start, but are not intended to be used
 ### inside this image in the real deployments.
-ARG REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com
+ARG REPOSITORY=neondatabase
 ARG IMAGE=rust
 ARG TAG=pinned
 
 # Build Postgres
 FROM $REPOSITORY/$IMAGE:$TAG AS pg-build
+USER nonroot
 WORKDIR /home/nonroot
 
 COPY --chown=nonroot vendor/postgres-v14 vendor/postgres-v14
@@ -39,7 +40,7 @@ ARG CACHEPOT_BUCKET=neon-github-dev
 
 COPY --from=pg-build /home/nonroot/pg_install/v14/include/postgresql/server pg_install/v14/include/postgresql/server
 COPY --from=pg-build /home/nonroot/pg_install/v15/include/postgresql/server pg_install/v15/include/postgresql/server
-COPY . .
+COPY --chown=nonroot . .
 
 # Show build caching stats to check if it was used in the end.
 # Has to be the part of the same RUN since cachepot daemon is killed in the end of this RUN, losing the compilation stats.

--- a/Dockerfile.compute-node-v14
+++ b/Dockerfile.compute-node-v14
@@ -150,7 +150,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN) \
 # Compile and run the Neon-specific `compute_ctl` binary
 #
 #########################################################################################
-FROM 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:$TAG AS compute-tools
+FROM neondatabase/rust:$TAG AS compute-tools
 USER nonroot
 # Copy entire project to get Cargo.* files with proper dependencies for the whole project
 COPY --chown=nonroot . .

--- a/Dockerfile.compute-node-v15
+++ b/Dockerfile.compute-node-v15
@@ -150,7 +150,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN) \
 # Compile and run the Neon-specific `compute_ctl` binary
 #
 #########################################################################################
-FROM 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:$TAG AS compute-tools
+FROM neondatabase/rust:$TAG AS compute-tools
 USER nonroot
 # Copy entire project to get Cargo.* files with proper dependencies for the whole project
 COPY --chown=nonroot . .

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -1,10 +1,11 @@
 # First transient image to build compute_tools binaries
 # NB: keep in sync with rust image version in .github/workflows/build_and_test.yml
-ARG REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com
+ARG REPOSITORY=neondatabase
 ARG IMAGE=rust
 ARG TAG=pinned
 
 FROM $REPOSITORY/$IMAGE:$TAG AS rust-build
+USER nonroot
 WORKDIR /home/nonroot
 
 # Enable https://github.com/paritytech/cachepot to cache Rust crates' compilation results in Docker builds.
@@ -17,7 +18,7 @@ ARG CACHEPOT_BUCKET=neon-github-dev
 #ARG AWS_ACCESS_KEY_ID
 #ARG AWS_SECRET_ACCESS_KEY
 
-COPY . .
+COPY --chown=nonroot . .
 
 RUN set -e \
     && mold -run cargo build -p compute_tools --locked --release \

--- a/docker-compose/compute_wrapper/Dockerfile
+++ b/docker-compose/compute_wrapper/Dockerfile
@@ -1,4 +1,4 @@
-ARG REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com
+ARG REPOSITORY=neondatabase
 ARG COMPUTE_IMAGE=compute-node-v14
 ARG TAG=latest
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -174,6 +174,7 @@ services:
     build:
       context: ./compute_wrapper/
       args:
+        - REPOSITORY=${REPOSITORY:-neondatabase}
         - COMPUTE_IMAGE=compute-node-v${PG_VERSION:-14}
         - TAG=${TAG:-latest}
         - http_proxy=$http_proxy


### PR DESCRIPTION
Do this so that we benefit from the CI pipelines of Neon. More importantly, the Docker images are automatically built and pushed, which helps in automating the experiment setup.

https://hub.docker.com/repository/docker/ctring/neon
https://hub.docker.com/repository/docker/ctring/compute-node-v14
https://hub.docker.com/repository/docker/ctring/compute-node-v15
https://hub.docker.com/repository/docker/ctring/compute-tools

