### PR TITLE
Validate index scans for remotexacts

### DIFF
--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -51,9 +51,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	dlist_foreach(rel_iter, &rwset->relations)
 	{
 		RWSetRelation *rel = dlist_container(RWSetRelation, node, rel_iter.cur);
-		Oid relid = rel->relid;
 		int8 region = rel->region;
-		XidCSN read_csn = rel->csn;
 
 		if (region != current_region)
 			continue;
@@ -67,7 +65,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 		if (rel->is_index && !rel->is_table_scan)
 			validate_index_scan(rel);
 		else if (!rel->is_index && rel->is_table_scan)
-			validate_table_scan(relid, read_csn); 
+			validate_table_scan(rel); 
 	}
 
 	/*

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -58,8 +58,16 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 		if (region != current_region)
 			continue;
 
-		if (!rel->is_index && rel->is_table_scan)
-			validate_table_scan(relid, read_csn);
+		/* TODO(pooja): Better organize this code in the following order:
+		 * 1. Index scan
+		 * 2. Tuple scans
+		 * 3. Table scan
+		 */
+		
+		if (rel->is_index && !rel->is_table_scan)
+			validate_index_scan(rel);
+		else if (!rel->is_index && rel->is_table_scan)
+			validate_table_scan(relid, read_csn); 
 	}
 
 	/*

--- a/pgxn/remotexact/validate.h
+++ b/pgxn/remotexact/validate.h
@@ -14,6 +14,6 @@
 #include "utils/snapshot.h"
 
 void validate_index_scan(RWSetRelation *rw_rel);
-void validate_table_scan(Oid relid, XidCSN read_csn);
+void validate_table_scan(RWSetRelation *rw_rel);
 
 #endif							/* VALIDATE_H */

--- a/pgxn/remotexact/validate.h
+++ b/pgxn/remotexact/validate.h
@@ -13,6 +13,7 @@
 
 #include "utils/snapshot.h"
 
+void validate_index_scan(RWSetRelation *rw_rel);
 void validate_table_scan(Oid relid, XidCSN read_csn);
 
 #endif							/* VALIDATE_H */


### PR DESCRIPTION
Validates index reads by checking if any of the index pages collected by the remotexact have been updated since the read_csn. If any such updates are found, we abort immediately. This helps us handle the case of phantom reads.

The next step would be to validate specific tuples within a table scan. Validating individual index entries might be tricky and not necessarily required in the common case.

This change can't be merged before https://github.com/DSLAM-UMD/postgres/pull/61 and https://github.com/DSLAM-UMD/postgres/pull/62


Testing: 
Multiregion setup: 
```
CREATE EXTENSION remotexact;
CREATE TABLE measurement (logdate DATE PRIMARY KEY, value INT) PARTITION BY RANGE (logdate);
CREATE INDEX measurement_value_idx ON measurement(value); 
CREATE TABLE measurement_y2021 PARTITION OF measurement FOR VALUES FROM ('2021-01-01') TO ('2021-12-31');
CREATE TABLE measurement_y2022 PARTITION OF measurement FOR VALUES FROM ('2022-01-01') TO ('2022-12-31');
UPDATE pg_class SET relregion = 1 WHERE relname = 'measurement_y2021';
UPDATE pg_class SET relregion = 1 WHERE relname = 'measurement_y2021_pkey';
UPDATE pg_class SET relregion = 2 WHERE relname = 'measurement_y2022';
UPDATE pg_class SET relregion = 2 WHERE relname = 'measurement_y2022_pkey';
UPDATE pg_class SET relregion = 1 WHERE relname = 'measurement_y2021_value_idx';
UPDATE pg_class SET relregion = 2 WHERE relname = 'measurement_y2022_value_idx';
```

In region 1: 
```
BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
UPDATE measurement SET value = 100 WHERE value = 50;
```

In region 2:
```
UPDATE measurement SET value = 200 WHERE value = 50;
```

Followed by commit at region 1: 
```
COMMIT; 
ERROR:  [remotexact] validation failed
```
The error logs captured in the remotexact server at region 2: 
```
    Caused by:
        0: db error: ERROR: read out-of-date index data from a remote partition
        1: ERROR: read out-of-date index data from a remote partition
```


I have also tried some other cases, including success cases. 
The only drawback with the current approach is that it fails validation even if other tuples in the index page were updated, eg the following transaction in region 2 causes the remotexact at region 1 to fail: 
```
UPDATE measurement SET value = 200 WHERE value = 40;
```
