### PR TITLE
Reorganize the readset

### DIFF
--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -19,7 +19,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	bytea	   *bytes = PG_GETARG_BYTEA_P(0);
 	StringInfoData buf;
 	RWSet	   *rwset;
-	dlist_iter	rel_iter;
+	int i;
 
 	/*
 	 * Signify that this is a surrogate transaction. This
@@ -48,9 +48,9 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	/*
 	 * Validate the read set
 	 */
-	dlist_foreach(rel_iter, &rwset->relations)
+	for (i = 0; i < rwset->n_relations; i++)
 	{
-		RWSetRelation *rel = dlist_container(RWSetRelation, node, rel_iter.cur);
+		RWSetRelation *rel = &(rwset->relations[i]);
 		int8 region = rel->region;
 
 		if (region != current_region)

--- a/pgxn/remotexact/rwset.c
+++ b/pgxn/remotexact/rwset.c
@@ -10,12 +10,12 @@
 #include "utils/memutils.h"
 
 static void decode_header(RWSet *rwset, StringInfo msg);
-static RWSetRelation *decode_relation(RWSet *rwset, StringInfo msg);
-static RWSetRelation *alloc_relation(RWSet *rwset);
-static RWSetPage *decode_page(RWSet *rwset, StringInfo msg);
-static RWSetPage *alloc_page(RWSet *rwset);
-static RWSetTuple *decode_tuple(RWSet *rwset, StringInfo msg);
-static RWSetTuple *alloc_tuple(RWSet *rwset);
+static RWSetRelation *alloc_relations(RWSet *rwset);
+static void decode_relation(RWSet *rwset, RWSetRelation *rel, StringInfo msg);
+static RWSetPage *alloc_pages(RWSet *rwset, RWSetRelation *rel);
+static void decode_page(RWSetPage * page, StringInfo msg);
+static RWSetTuple *alloc_tuples(RWSet *rwset, RWSetRelation *rel);
+static void decode_tuple(RWSetTuple *, StringInfo msg);
 
 static void append_tuple_string(StringInfo str, const LogicalRepTupleData *tuple);
 static void free_tuple(LogicalRepTupleData* tuple);
@@ -35,7 +35,8 @@ RWSetAllocate(void)
 
 	rwset->header.dbid = 0;
 
-	dlist_init(&rwset->relations);
+	rwset->n_relations = 0;
+	rwset->relations = NULL;
 
 	rwset->writes = NULL;
 	rwset->writes_len = 0;
@@ -53,12 +54,18 @@ void
 RWSetDecode(RWSet *rwset, StringInfo msg)
 {
 	int			read_set_len;
+	int			num_rels;
 	int			consumed = 0;
+	int			num_rels_received = 0;
 	int			prev_cursor;
 
 	decode_header(rwset, msg);
 
 	read_set_len = pq_getmsgint(msg, 4);
+	num_rels = pq_getmsgint(msg, 4);
+
+	// Allocate relations based on number of relations expected.
+	rwset->relations = alloc_relations(rwset);
 
 	if (read_set_len > msg->len)
 		ereport(ERROR,
@@ -67,21 +74,26 @@ RWSetDecode(RWSet *rwset, StringInfo msg)
 
 	while (consumed < read_set_len)
 	{
-		RWSetRelation *rel;
+		RWSetRelation *rel = &(rwset->relations[num_rels_received]);
 
 		prev_cursor = msg->cursor;
 
-		rel = decode_relation(rwset, msg);
-		dlist_push_tail(&rwset->relations, &rel->node);
+		decode_relation(rwset, rel, msg);
 
 		consumed += msg->cursor - prev_cursor;
+		num_rels_received++;
 	}
 
 	if (consumed > read_set_len)
 		ereport(ERROR,
 				errmsg("length of read set (%d) is corrupted", read_set_len),
 				errdetail("length of decoded read set: %d", consumed));
-	
+	if(num_rels != num_rels_received)
+          ereport(ERROR,
+              errmsg("number of read relations (%d) does not match relations "
+                     "received", num_rels),
+              errdetail("number of relations received: %d", num_rels_received));
+
 	rwset->writes_len = msg->len - msg->cursor;
 	rwset->writes = (char *) MemoryContextAlloc(rwset->context, sizeof(char) * rwset->writes_len);
 	pq_copymsgbytes(msg, rwset->writes, rwset->writes_len);
@@ -95,14 +107,26 @@ decode_header(RWSet *rwset, StringInfo msg)
 }
 
 RWSetRelation *
-decode_relation(RWSet *rwset, StringInfo msg)
+alloc_relations(RWSet *rwset)
 {
-	RWSetRelation *rel;
+	MemoryContext ctx;
+	RWSetRelation *rels;
+
+	ctx = rwset->context;
+	rels = (RWSetRelation *)MemoryContextAlloc(
+		ctx, rwset->n_relations * sizeof(RWSetRelation));
+    memset(rels, 0, rwset->n_relations * sizeof(RWSetRelation));
+	Assert(rels != NULL);
+
+	return rels;
+}
+
+void
+decode_relation(RWSet *rwset, RWSetRelation *rel, StringInfo msg)
+{
 	unsigned char reltype;
 	int			nitems;
 	int			i;
-
-	rel = alloc_relation(rwset);
 
 	reltype = pq_getmsgbyte(msg);
 
@@ -120,93 +144,71 @@ decode_relation(RWSet *rwset, StringInfo msg)
 	nitems = pq_getmsgint(msg, 4);
 
 	if (rel->is_index)
+	{
+		rel->n_pages = nitems;
+		rel->pages = alloc_pages(rwset, rel);
 		for (i = 0; i < nitems; i++)
 		{
-			RWSetPage  *page = decode_page(rwset, msg);
-			dlist_push_tail(&rel->pages, &page->node);
+			decode_page(&(rel->pages[i]), msg);
 		}
+	}
 	else
+	{
+		rel->n_tuples = nitems;
+		rel->tuples = alloc_tuples(rwset, rel);
 		for (i = 0; i < nitems; i++)
 		{
-			RWSetTuple *tup = decode_tuple(rwset, msg);
-			dlist_push_tail(&rel->tuples, &tup->node);
+			decode_tuple(&(rel->tuples[i]), msg);
 		}
-
-	return rel;
+	}
 }
 
-RWSetRelation *
-alloc_relation(RWSet *rwset)
-{
-	MemoryContext ctx;
-	RWSetRelation *rel;
-
-	ctx = rwset->context;
-	rel = (RWSetRelation *) MemoryContextAlloc(ctx, sizeof(RWSetRelation));
-
-	memset(rel, 0, sizeof(RWSetRelation));
-
-	dlist_init(&rel->pages);
-	dlist_init(&rel->tuples);
-
-	return rel;
-}
 
 RWSetPage *
-decode_page(RWSet *rwset, StringInfo msg)
+alloc_pages(RWSet *rwset, RWSetRelation *rel)
 {
-	RWSetPage  *page;
+	MemoryContext ctx;
+	RWSetPage  *pages;
 
-	page = alloc_page(rwset);
+	ctx = rwset->context;
+	pages = (RWSetPage *)MemoryContextAlloc(
+		ctx, rel->n_pages * sizeof(RWSetPage));
 
+    memset(pages, 0, rel->n_pages * sizeof(RWSetPage));
+
+	return pages;
+}
+
+void 
+decode_page(RWSetPage *page, StringInfo msg)
+{
 	page->blkno = pq_getmsgint(msg, 4);
-
-	return page;
-}
-
-
-RWSetPage *
-alloc_page(RWSet *rwset)
-{
-	MemoryContext ctx;
-	RWSetPage  *page;
-
-	ctx = rwset->context;
-	page = (RWSetPage *) MemoryContextAlloc(ctx, sizeof(RWSetPage));
-
-	memset(page, 0, sizeof(RWSetPage));
-
-	return page;
 }
 
 RWSetTuple *
-decode_tuple(RWSet *rwset, StringInfo msg)
+alloc_tuples(RWSet *rwset, RWSetRelation *rel)
 {
-	RWSetTuple *tup;
+	MemoryContext ctx;
+	RWSetTuple *tuples;
+
+	ctx = rwset->context;
+	tuples = (RWSetTuple *)MemoryContextAlloc(
+		ctx, rel->n_tuples * sizeof(RWSetTuple));
+
+	memset(tuples, 0, rel->n_tuples * sizeof(RWSetTuple));
+
+	return tuples;
+}
+
+void
+decode_tuple(RWSetTuple *tuple, StringInfo msg)
+{
 	int			blkno;
 	int			offset;
 
 	blkno = pq_getmsgint(msg, 4);
 	offset = pq_getmsgint(msg, 2);
-
-	tup = alloc_tuple(rwset);
-	ItemPointerSet(&tup->tid, blkno, offset);
-
-	return tup;
-}
-
-RWSetTuple *
-alloc_tuple(RWSet *rwset)
-{
-	MemoryContext ctx;
-	RWSetTuple *tup;
-
-	ctx = rwset->context;
-	tup = (RWSetTuple *) MemoryContextAlloc(ctx, sizeof(RWSetTuple));
-
-	memset(tup, 0, sizeof(RWSetTuple));
-
-	return tup;
+	ItemPointerSet(&tuple->tid, blkno, offset);
 }
 
 char *
@@ -216,7 +218,7 @@ RWSetToString(RWSet *rwset)
 	bool	first_group = true;
 
 	RWSetHeader *header;
-	dlist_iter	rel_iter;
+	int i;
 
 	StringInfoData writes_cur;
 
@@ -225,16 +227,16 @@ RWSetToString(RWSet *rwset)
 	/* Header */
 	header = &rwset->header;
 	appendStringInfoString(&s, "{\n\"header\": ");
-	appendStringInfo(&s, "{ \"dbid\": %d, \"region_set\": %ld }", 
+	appendStringInfo(&s, "{ \"dbid\": %d, \"region_set\": %ld }",
 					 header->dbid, header->region_set);
 
 	/* Relations */
 	appendStringInfoString(&s, ",\n\"relations\": [");
-	dlist_foreach(rel_iter, &rwset->relations)
+	for (i = 0; i < rwset->n_relations; i++)
 	{
-		RWSetRelation *rel = dlist_container(RWSetRelation, node, rel_iter.cur);
-		dlist_iter	item_iter;
-		bool		first_item;
+		RWSetRelation *rel = &(rwset->relations[i]);
+		int j;
+		bool first_item;
 
 		if (!first_group)
 			appendStringInfoString(&s, ",");
@@ -245,15 +247,16 @@ RWSetToString(RWSet *rwset)
 		appendStringInfo(&s, ", \"relid\": %d", rel->relid);
 		appendStringInfo(&s, ", \"region\": %d", rel->region);
 		appendStringInfo(&s, ", \"csn\": %ld", rel->csn);
+		appendStringInfo(&s, ", \"is_table_scan\": %d", rel->is_table_scan);
 
 		/* Pages */
-		if (!dlist_is_empty(&rel->pages))
+		if (rel->n_pages != 0)
 		{
 			appendStringInfoString(&s, ",\n\t \"pages\": [");
 			first_item = true;
-			dlist_foreach(item_iter, &rel->pages)
+			for (j = 0; j < rel->n_pages; j++)
 			{
-				RWSetPage  *page = dlist_container(RWSetPage, node, item_iter.cur);
+				RWSetPage *page = &(rel->pages[j]);
 
 				if (!first_item)
 					appendStringInfoString(&s, ",");
@@ -267,13 +270,13 @@ RWSetToString(RWSet *rwset)
 		}
 
 		/* Tuples */
-		if (!dlist_is_empty(&rel->tuples))
+		if (rel->n_tuples != 0)
 		{
 			appendStringInfoString(&s, ",\n\t \"tuples\": [");
 			first_item = true;
-			dlist_foreach(item_iter, &rel->tuples)
+			for (j = 0; j < rel->n_tuples; j++)
 			{
-				RWSetTuple *tup = dlist_container(RWSetTuple, node, item_iter.cur);
+				RWSetTuple *tup = &(rel->tuples[j]);
 
 				if (!first_item)
 					appendStringInfoString(&s, ",");
@@ -293,7 +296,7 @@ RWSetToString(RWSet *rwset)
 
 	/* Writes */
 	appendStringInfoString(&s, ",\n\"writes\": [");
-	
+
 	writes_cur.data = rwset->writes;
 	writes_cur.len = rwset->writes_len;
 	writes_cur.cursor = 0;

--- a/pgxn/remotexact/rwset.c
+++ b/pgxn/remotexact/rwset.c
@@ -54,7 +54,6 @@ void
 RWSetDecode(RWSet *rwset, StringInfo msg)
 {
 	int			read_set_len;
-	int			num_rels;
 	int			consumed = 0;
 	int			num_rels_received = 0;
 	int			prev_cursor;
@@ -62,7 +61,7 @@ RWSetDecode(RWSet *rwset, StringInfo msg)
 	decode_header(rwset, msg);
 
 	read_set_len = pq_getmsgint(msg, 4);
-	num_rels = pq_getmsgint(msg, 4);
+	rwset->n_relations = pq_getmsgint(msg, 4);
 
 	// Allocate relations based on number of relations expected.
 	rwset->relations = alloc_relations(rwset);
@@ -88,10 +87,10 @@ RWSetDecode(RWSet *rwset, StringInfo msg)
 		ereport(ERROR,
 				errmsg("length of read set (%d) is corrupted", read_set_len),
 				errdetail("length of decoded read set: %d", consumed));
-	if(num_rels != num_rels_received)
+	if(rwset->n_relations != num_rels_received)
           ereport(ERROR,
               errmsg("number of read relations (%d) does not match relations "
-                     "received", num_rels),
+                     "received", rwset->n_relations),
               errdetail("number of relations received: %d", num_rels_received));
 
 	rwset->writes_len = msg->len - msg->cursor;

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -32,8 +32,6 @@ typedef struct RWSetHeader
 typedef struct RWSetPage
 {
 	BlockNumber blkno;
-
-	dlist_node	node;
 } RWSetPage;
 
 /*
@@ -42,8 +40,6 @@ typedef struct RWSetPage
 typedef struct RWSetTuple
 {
 	ItemPointerData tid;
-
-	dlist_node	node;
 } RWSetTuple;
 
 /*
@@ -56,10 +52,10 @@ typedef struct RWSetRelation
 	int8		region;
 	XidCSN		csn;
 	bool		is_table_scan;
-	dlist_head	pages;
-	dlist_head	tuples;
-
-	dlist_node	node;
+	int			n_pages;
+	RWSetPage	*pages;
+	int 		n_tuples;
+	RWSetTuple	*tuples;
 } RWSetRelation;
 
 /*
@@ -67,11 +63,12 @@ typedef struct RWSetRelation
  */
 typedef struct RWSet
 {
-	MemoryContext context;
-	RWSetHeader header;
-	dlist_head	relations;
-	char	   *writes;
-	int			writes_len;
+	MemoryContext 	context;
+	RWSetHeader 	header;
+	int 			n_relations;
+	RWSetRelation	*relations;
+	char	   		*writes;
+	int				writes_len;
 } RWSet;
 
 extern RWSet *RWSetAllocate(void);

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -11,7 +11,6 @@
 
 #include "postgres.h"
 
-#include "lib/ilist.h"
 #include "lib/stringinfo.h"
 #include "storage/block.h"
 #include "storage/itemptr.h"

--- a/pgxn/remotexact/validate.c
+++ b/pgxn/remotexact/validate.c
@@ -28,7 +28,7 @@ void validate_index_scan(RWSetRelation *rw_rel)
     int nkeys = 0;
     ScanKey keys = NULL;
     int scan_flags = 0;
-    dlist_iter page_iter;
+    int i; 
     RWSetPage *page = NULL;
     Page index_page;
     XLogRecPtr page_lsn = InvalidXLogRecPtr;
@@ -43,11 +43,11 @@ void validate_index_scan(RWSetRelation *rw_rel)
     scan = (HeapScanDesc)heap_beginscan(rel, SnapshotAny, nkeys, keys, NULL,
                                         scan_flags);
 
-    // For each index page, check if the lsn has been updated. 
-    dlist_foreach(page_iter, &rw_rel->pages)
+    // For each index page, check if the lsn has been updated.
+    for (i = 0; i < rw_rel->n_pages; i++)
     {
-        page = dlist_container(RWSetPage, node, page_iter.cur);
-        
+        page = &(rw_rel->pages[i]);
+
         // Advance the hscan to specified block and lock the page for sharing.
         heap_getpageonly(scan, page->blkno);
         LockBuffer(scan->rs_cbuf, BUFFER_LOCK_SHARE);


### PR DESCRIPTION
This change sends information about the number of relations, pages and tuples while sending the readset. The Readset at the receiver's end now uses arrays instead of dlist, making it better suited for sorting the array based on priority and page numbers. 