### PR TITLE
Return timeline region ids in pageserver rest api

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -157,6 +157,8 @@ pub struct TenantInfo {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TimelineInfo {
     #[serde_as(as = "DisplayFromStr")]
+    pub region_id: RegionId, // Remotexact
+    #[serde_as(as = "DisplayFromStr")]
     pub tenant_id: TenantId,
     #[serde_as(as = "DisplayFromStr")]
     pub timeline_id: TimelineId,

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -138,6 +138,7 @@ async fn build_timeline_info(
     let state = timeline.current_state();
 
     let info = TimelineInfo {
+        region_id: timeline.region_id,
         tenant_id: timeline.tenant_id,
         timeline_id: timeline.timeline_id,
         ancestor_timeline_id,


### PR DESCRIPTION
Return this information so a compute node can automatically select the timeline for its region in a deployment. 
```
> curl http://127.0.0.1:9898/v1/tenant/35de5f1579d881e2a57ede42c577f92c/timeline
[{
"region_id":"0",                                           <--- this is new
"tenant_id":"35de5f1579d881e2a57ede42c577f92c",
"timeline_id":"53323ae593379ded9114d68136f1753b",
"ancestor_timeline_id":null,
...
}]
```