### PR TITLE
Refactor the readset validation code 

### DIFF
--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -74,9 +74,10 @@ static int tuple_comparator(const void *p1, const void *p2)
 	RWSetTuple t1 = *(const RWSetTuple *)p1;
 	RWSetTuple t2 = *(const RWSetTuple *)p2;
 
-	BlockNumber b1 = BlockIdGetBlockNumber(&(t1.tid.ip_blkid));
-	BlockNumber b2 = BlockIdGetBlockNumber(&(t2.tid.ip_blkid));
-
+	BlockNumber b1 = ItemPointerGetBlockNumber(&(t1.tid));
+	BlockNumber b2 = ItemPointerGetBlockNumber(&(t2.tid));
+	OffsetNumber o1 = ItemPointerGetOffsetNumber(&(t1.tid));
+	OffsetNumber o2 = ItemPointerGetOffsetNumber(&(t2.tid));
 
 	if (b1 < b2)
 		return -1;
@@ -86,9 +87,9 @@ static int tuple_comparator(const void *p1, const void *p2)
 	/* Both tuples belong to the same block. */
 	Assert(b1 == b2);
 
-	if (t1.tid.ip_posid < t2.tid.ip_posid)
+	if (o1 < o2)
 		return -1;
-	else if (t1.tid.ip_posid > t2.tid.ip_posid)
+	else if (o1 > o2)
 		return 1;
 
 	/* Ideally, we should not get the same tuple twice. */

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -458,9 +458,13 @@ rx_execute_remote_xact(void)
 		pq_sendbyte(&buf, region);
 		pq_sendint64(&buf, csn);
 		pq_sendbyte(&buf, is_table_scan);
-		pq_sendint32(&buf, nitems);
-		pq_sendbytes(&buf, items->data, items->len);
-
+		/* Skip sending the tuples if a relation is a table scan. */
+		if (!is_table_scan) {
+			pq_sendint32(&buf, nitems);
+			pq_sendbytes(&buf, items->data, items->len);
+		} else {
+			pq_sendint32(&buf, 0);
+		}
 		read_len += buf.len;
 		num_read_rels++;
 	}

--- a/pgxn/remotexact/validate.c
+++ b/pgxn/remotexact/validate.c
@@ -194,7 +194,7 @@ validate_tuple_scan(RWSetRelation *rw_rel)
     Relation        rel;
     int             i;
     Snapshot        snapshot = GetActiveSnapshot();
-	HeapTupleData   htup;
+    HeapTupleData   htup;
     Buffer          buf = InvalidBuffer;
     bool            valid = false;
 

--- a/pgxn/remotexact/validate.h
+++ b/pgxn/remotexact/validate.h
@@ -15,5 +15,6 @@
 
 void validate_index_scan(RWSetRelation *rw_rel);
 void validate_table_scan(RWSetRelation *rw_rel);
+void validate_tuple_scan(RWSetRelation *rw_rel);
 
 #endif							/* VALIDATE_H */


### PR DESCRIPTION
This change makes a couple of changes to the validation workflow: 

1. Sort the readset and validate the relations in the order of table->index->tuples.
2. Sort pages and tuples before validation to use prefetching. (TODO: change the corresponding function in Postgres).
3. Validate tuple scans.

Minor optimization at the remote region: 
Send the tuples for validation only if `is_table_scan = false`. It ensures that when a transaction carries out a full table scan, we can simply skip the tuple validations. 


Testing:
Printed the readset after the various sorts to ensure that the order is the same as expected. 

For the tuple scan validation: Disabled the index validation and ensured that the tuple validation alone would suffice. In the general case, index validation alone will catch any tuple updates. 