### PR TITLE
Add mc and remotexact to the docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN set -e \
         libseccomp-dev \
         openssl \
         ca-certificates \
+        curl \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && useradd -d /data neon \
     && chown -R neon:neon /data
@@ -84,6 +85,11 @@ RUN mkdir -p /data/.neon/ && chown -R neon:neon /data/.neon/ \
        -c "pg_distrib_dir='/usr/local/'" \
        -c "listen_pg_addr='0.0.0.0:6400'" \
        -c "listen_http_addr='0.0.0.0:9898'"
+
+RUN curl https://dl.min.io/client/mc/release/linux-amd64/mc \
+         --create-dirs \
+         -o /usr/bin/mc \
+    && chmod +x /usr/bin/mc
 
 VOLUME ["/data"]
 USER neon

--- a/Dockerfile.compute-node-v14
+++ b/Dockerfile.compute-node-v14
@@ -145,6 +145,11 @@ RUN make -j $(getconf _NPROCESSORS_ONLN) \
         -C pgxn/neon \
         -s install
 
+RUN make -j $(getconf _NPROCESSORS_ONLN) \
+        PG_CONFIG=/usr/local/pgsql/bin/pg_config \
+        -C pgxn/remotexact \
+        -s install
+
 #########################################################################################
 #
 # Compile and run the Neon-specific `compute_ctl` binary

--- a/Dockerfile.compute-node-v15
+++ b/Dockerfile.compute-node-v15
@@ -145,6 +145,11 @@ RUN make -j $(getconf _NPROCESSORS_ONLN) \
         -C pgxn/neon \
         -s install
 
+RUN make -j $(getconf _NPROCESSORS_ONLN) \
+        PG_CONFIG=/usr/local/pgsql/bin/pg_config \
+        -C pgxn/remotexact \
+        -s install
+
 #########################################################################################
 #
 # Compile and run the Neon-specific `compute_ctl` binary


### PR DESCRIPTION
mc is the client for minio, which is a replacement for S3. We use it to distribute the initial base data in the cluster.