### PR TITLE
Disable DDL in compute_tools

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -292,7 +292,8 @@ impl ComputeNode {
         handle_databases(&self.spec, &mut client)?;
         handle_role_deletions(self, &mut client)?;
         handle_grants(self, &mut client)?;
-        create_writablity_check_data(&mut client)?;
+        // Remotexact - disable this function because it run DDL statements
+        // create_writablity_check_data(&mut client)?;
 
         // 'Close' connection
         drop(client);


### PR DESCRIPTION
This function call creates a "health_check" table that we don't need.