### PR TITLE
docker-compose config for multi-region deployment

### DIFF
--- a/docker-compose/compute_wrapper/shell/compute-multi-region.sh
+++ b/docker-compose/compute_wrapper/shell/compute-multi-region.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eux
+
+PG_VERSION=${PG_VERSION:-14}
+
+SPEC_FILE_ORG=/var/db/postgres/specs/spec-multi-region.json
+SPEC_FILE=/tmp/spec.json
+
+echo "Waiting pageserver become ready."
+while ! nc -z ${PAGESERVER_HOST} 6400; do
+     sleep 1;
+done
+echo "Page server is ready."
+
+tenant_id=$(curl -s http://${PAGESERVER_HOST}:9898/v1/tenant/ | jq -r '.[0].id')
+
+echo "Tenant id: ${tenant_id}"
+timelines=$(curl -s http://${PAGESERVER_HOST}:9898/v1/tenant/${tenant_id}/timeline/)
+
+region_id_to_timeline_id=$(echo ${timelines} | jq '[.[] | {key: .region_id, value: .timeline_id}] | from_entries')
+
+timeline_id=$(echo ${region_id_to_timeline_id} | jq -r ".[\"${REGION}\"]")
+
+echo "Selected timeline ${timeline_id} for region ${REGION}"
+echo "Overwrite tenant id and timeline id in spec file"
+
+sed "s/TENANT_ID/${tenant_id}/" ${SPEC_FILE_ORG} > ${SPEC_FILE}
+sed -i "s/TIMELINE_ID/${timeline_id}/" ${SPEC_FILE}
+sed -i "s/SAFEKEEPERS_ADDR/${SAFEKEEPERS_ADDR}/" ${SPEC_FILE}
+sed -i "s/PAGESERVER_HOST/${PAGESERVER_HOST}/" ${SPEC_FILE}
+sed -i "s/XACTSERVER/${XACTSERVER}/" ${SPEC_FILE}
+sed -i "s/REGION/${REGION}/" ${SPEC_FILE}
+
+cat ${SPEC_FILE}
+
+echo "Start compute node"
+/usr/local/bin/compute_ctl --pgdata /var/db/postgres/compute \
+     -C "postgresql://cloud_admin@localhost:55433/postgres"  \
+     -b /usr/local/bin/postgres                              \
+     -S ${SPEC_FILE}

--- a/docker-compose/compute_wrapper/var/db/postgres/specs/spec-multi-region.json
+++ b/docker-compose/compute_wrapper/var/db/postgres/specs/spec-multi-region.json
@@ -1,0 +1,161 @@
+{
+    "format_version": 1.0,
+
+    "timestamp": "2022-10-12T18:00:00.000Z",
+    "operation_uuid": "0f657b36-4b0f-4a2d-9c2e-1dcd615e7d8c",
+
+    "cluster": {
+        "cluster_id": "multi_region",
+        "name": "multi_region_neon",
+        "state": "restarted",
+        "roles": [
+        ],
+        "databases": [
+        ],
+        "settings": [
+            {
+                "name": "fsync",
+                "value": "off",
+                "vartype": "bool"
+            },
+            {
+                "name": "wal_level",
+                "value": "remote_xact",
+                "vartype": "enum"
+            },
+            {
+                "name": "hot_standby",
+                "value": "on",
+                "vartype": "bool"
+            },
+            {
+                "name": "wal_log_hints",
+                "value": "on",
+                "vartype": "bool"
+            },
+            {
+                "name": "log_connections",
+                "value": "on",
+                "vartype": "bool"
+            },
+            {
+                "name": "port",
+                "value": "55433",
+                "vartype": "integer"
+            },
+            {
+                "name": "shared_buffers",
+                "value": "1MB",
+                "vartype": "string"
+            },
+            {
+                "name": "max_connections",
+                "value": "100",
+                "vartype": "integer"
+            },
+            {
+                "name": "listen_addresses",
+                "value": "0.0.0.0",
+                "vartype": "string"
+            },
+            {
+                "name": "max_wal_senders",
+                "value": "10",
+                "vartype": "integer"
+            },
+            {
+                "name": "max_replication_slots",
+                "value": "10",
+                "vartype": "integer"
+            },
+            {
+                "name": "wal_sender_timeout",
+                "value": "5s",
+                "vartype": "string"
+            },
+            {
+                "name": "wal_keep_size",
+                "value": "0",
+                "vartype": "integer"
+            },
+            {
+                "name": "password_encryption",
+                "value": "md5",
+                "vartype": "enum"
+            },
+            {
+                "name": "restart_after_crash",
+                "value": "off",
+                "vartype": "bool"
+            },
+            {
+                "name": "synchronous_standby_names",
+                "value": "walproposer",
+                "vartype": "string"
+            },
+            {
+                "name": "shared_preload_libraries",
+                "value": "neon,remotexact",
+                "vartype": "string"
+            },
+            {
+                "name": "neon.safekeepers",
+                "value": "SAFEKEEPERS_ADDR",
+                "vartype": "string"
+            },
+            {
+                "name": "neon.timeline_id",
+                "value": "TIMELINE_ID",
+                "vartype": "string"
+            },
+            {
+                "name": "neon.tenant_id",
+                "value": "TENANT_ID",
+                "vartype": "string"
+            },
+            {
+                "name": "neon.pageserver_connstring",
+                "value": "host=PAGESERVER_HOST port=6400",
+                "vartype": "string"
+            },
+            {
+                "name": "max_replication_write_lag",
+                "value": "500MB",
+                "vartype": "string"
+            },
+            {
+                "name": "max_replication_flush_lag",
+                "value": "10GB",
+                "vartype": "string"
+            },
+            {
+                "name": "neon.slru_csnlog",
+                "value": "on",
+                "vartype": "bool"
+            },
+            {
+                "name": "enable_csn_snapshot",
+                "value": "on",
+                "vartype": "bool"
+            },
+            {
+                "name": "max_prepared_transactions",
+                "value": "64",
+                "vartype": "integer"
+            },
+            {
+                "name": "remotexact.connstring",
+                "value": "postgresql://XACTSERVER",
+                "vartype": "string"
+            },
+            {
+                "name": "current_region",
+                "value": "REGION",
+                "vartype": "integer"
+            }
+        ]
+    },
+
+    "delta_operations": [
+    ]
+}

--- a/docker-compose/docker-compose-multi-region.yml
+++ b/docker-compose/docker-compose-multi-region.yml
@@ -1,0 +1,322 @@
+# This YAML can be run using either docker-compose (single node) or Docker Swarm (multiple nodes).
+# 
+# Run with docker-compose: TODO
+#
+# Run with Docker Swarm: TODO
+#
+version: '3.8'
+
+configs:
+  compute_spec:
+    file: ./compute_wrapper/var/db/postgres/specs/spec-multi-region.json
+  compute_shell:
+    file: ./compute_wrapper/shell/compute-multi-region.sh
+
+volumes:
+  pageserver-r1-data:
+  pageserver-r2-data:
+
+services:
+  etcd:
+    restart: always
+    image: quay.io/coreos/etcd:v3.5.4
+    ports:
+      - 2379:2379
+      - 2380:2380
+    environment:
+      # This signifficantly speeds up etcd and we anyway don't persistent data there.
+      ETCD_UNSAFE_NO_FSYNC: "1"
+    command:
+      - "etcd"
+      - "--auto-compaction-mode=revision"
+      - "--auto-compaction-retention=1"
+      - "--name=etcd-cluster"
+      - "--initial-cluster-state=new"
+      - "--initial-cluster-token=etcd-cluster-1"
+      - "--initial-cluster=etcd-cluster=http://etcd:2380"
+      - "--initial-advertise-peer-urls=http://etcd:2380"
+      - "--advertise-client-urls=http://etcd:2379"
+      - "--listen-client-urls=http://0.0.0.0:2379"
+      - "--listen-peer-urls=http://0.0.0.0:2380"
+      - "--quota-backend-bytes=134217728" # 128 MB
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.role==manager
+
+  minio:
+    restart: always
+    image: quay.io/minio/minio:RELEASE.2022-11-17T23-20-09Z
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=password
+    command: server /data --address :9000 --console-address ":9001"
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.role==manager
+
+  #############################################
+  #                 REGION 1                  #
+  #############################################
+  pageserver-r1: &pageserver
+    restart: always
+    image: ctring/neon:${TAG:-latest}
+    environment:
+      - BROKER_ENDPOINT='http://etcd:2379'
+      - LISTEN_PG_ADDR=6400
+      - LISTEN_HTTP_ADDR=9898
+      #- RUST_BACKTRACE=1
+    ports:
+       #- 6400:6400  # pg protocol handler
+       - 9898:9898 # http endpoints
+    # volumes:
+    #   - type: volume
+    #     source: pageserver-r1-data
+    #     target: /data
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+    command:
+      - |
+        until (/usr/bin/mc alias set minio http://minio:9000 minio password) do
+             echo 'Waiting to start minio...' && sleep 1
+        done
+        rm -rf /data/.neon
+        /usr/bin/mc cp -r minio/neon/.neon /data
+        /usr/local/bin/pageserver -D /data/.neon/                                     \
+                                  -c "broker_endpoints=[$$BROKER_ENDPOINT]"           \
+                                  -c "listen_pg_addr='0.0.0.0:$$LISTEN_PG_ADDR'"      \
+                                  -c "listen_http_addr='0.0.0.0:$$LISTEN_HTTP_ADDR'"  \
+                                  -c "pg_distrib_dir='/usr/local/'"
+    depends_on:
+      - etcd
+      - minio
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_pageserver==true
+
+  safekeeper-r1-1: &safekeeper
+    restart: always
+    image: ctring/neon:${TAG:-latest}
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r1-1:5454
+      - SAFEKEEPER_ID=1
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      # While other services can connect to a safekeeper using its name, the safekeeper
+      # itself cannot resolve its own name (?!), hence cannot bind to the listen-pg 
+      # address. This line tricks the safekeeper to bind to 0.0.0.0.
+      - safekeeper-r1-1:0.0.0.0
+    ports:
+      #- 5454:5454 # pg protocol handler
+      - 7676:7676 # http endpoints
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+    command:
+      - |
+        until (/usr/bin/mc alias set minio http://minio:9000 minio password) do
+             echo 'Waiting to start minio...' && sleep 1
+        done
+        rm -rf /data/*
+        /usr/bin/mc cp -r minio/neon/.neon/safekeepers/sk1 /data
+        mv /data/sk1/* . && rm -r /data/sk1
+        safekeeper --listen-pg=$$SAFEKEEPER_ADVERTISE_URL \
+                   --listen-http='0.0.0.0:7676' \
+                   --id=$$SAFEKEEPER_ID \
+                   --broker-endpoints=$$BROKER_ENDPOINT \
+                   -D /data
+    depends_on:
+      - etcd
+      - minio
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper1==true
+
+  safekeeper-r1-2:
+    <<: *safekeeper
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r1-2:5454
+      - SAFEKEEPER_ID=2
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      - safekeeper-r1-2:0.0.0.0
+    ports: []
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper2==true
+
+  safekeeper-r1-3:
+    <<: *safekeeper
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r1-3:5454
+      - SAFEKEEPER_ID=3
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      - safekeeper-r1-3:0.0.0.0
+    ports: []
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper3==true
+
+  xactserver-r1: &xactserver
+    image: ctring/xactserver:${TAG:-latest}
+    environment:
+      - NODE_ID=1
+      - CONNECT_PG=postgresql://compute-r1:55433
+      - NODES=http://xactserver-r1:23000,http://xactserver-r2:23000
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+    command:
+      - |
+        /usr/local/bin/xactserver   \
+          --listen-pg=0.0.0.0:10000 \
+          --connect-pg=$$CONNECT_PG \
+          --node-id=$$NODE_ID       \
+          --nodes=$$NODES
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_xactserver==true
+
+  compute-r1: &compute
+    restart: always
+    build:
+      context: ./compute_wrapper/
+      args:
+        - REPOSITORY=ctring
+        - COMPUTE_IMAGE=compute-node-v${PG_VERSION:-14}
+        - TAG=${TAG:-latest}
+        - http_proxy=$http_proxy
+        - https_proxy=$https_proxy
+    image: localhost:5000/compute-node-v${PG_VERSION:-14}:${TAG:-latest}
+    environment:
+      - PG_VERSION=${PG_VERSION:-14}
+      - PAGESERVER_HOST=pageserver-r1
+      - SAFEKEEPERS_ADDR=safekeeper-r1-1:5454,safekeeper-r1-2:5454,safekeeper-r1-3:5454
+      - REGION=1
+      - XACTSERVER=xactserver-r1:10000
+      #- RUST_BACKTRACE=1
+    # Mount these as configs instead of volumes so that it works correctly in swarm mode
+    configs:
+      - source: compute_spec
+        target: /var/db/postgres/specs/spec-multi-region.json
+      - source: compute_shell
+        target: /shell/compute-multi-region.sh
+        mode: 0555 # readable and executable
+    ports:
+      - 55433:55433 # pg protocol handler
+    entrypoint:
+      - "/shell/compute-multi-region.sh"
+    depends_on:
+      - safekeeper-r1-1
+      - safekeeper-r1-2
+      - safekeeper-r1-3
+      - pageserver-r1
+      - xactserver-r1
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_compute==true
+
+  #############################################
+  #                 REGION 2                  #
+  #############################################
+  pageserver-r2:
+    <<: *pageserver
+    environment:
+      - BROKER_ENDPOINT='http://etcd:2379'
+      - LISTEN_PG_ADDR=6400
+      - LISTEN_HTTP_ADDR=9898
+      #- RUST_BACKTRACE=1
+    ports:
+       #- 6400:6400  # pg protocol handler
+       - 9899:9898 # http endpoints
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_pageserver==true
+
+  safekeeper-r2-1:
+    <<: *safekeeper
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r2-1:5454
+      - SAFEKEEPER_ID=1
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      - safekeeper-r2-1:0.0.0.0
+    ports: []
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper2==true
+
+  safekeeper-r2-2:
+    <<: *safekeeper
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r2-2:5454
+      - SAFEKEEPER_ID=2
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      - safekeeper-r2-2:0.0.0.0
+    ports: []
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper2==true
+
+  safekeeper-r2-3:
+    <<: *safekeeper
+    environment:
+      - SAFEKEEPER_ADVERTISE_URL=safekeeper-r2-3:5454
+      - SAFEKEEPER_ID=3
+      - BROKER_ENDPOINT=http://etcd:2379
+      #- RUST_BACKTRACE=1
+    extra_hosts:
+      - safekeeper-r2-3:0.0.0.0
+    ports: []
+    # deploy:
+    #   placement:
+    #     constraints:
+    #       - node.labels.has_safekeeper2==true
+
+  xactserver-r2:
+    <<: *xactserver
+    environment:
+      - NODE_ID=2
+      - CONNECT_PG=postgresql://compute-r2:55433
+      - NODES=http://xactserver-r1:23000,http://xactserver-r2:23000
+
+  compute-r2:
+    <<: *compute
+    environment:
+      - PG_VERSION=${PG_VERSION:-14}
+      - PAGESERVER_HOST=pageserver-r2
+      - SAFEKEEPERS_ADDR=safekeeper-r2-1:5454,safekeeper-r2-2:5454,safekeeper-r2-3:5454
+      - REGION=2
+      - XACTSERVER=xactserver-r2:10000
+      #- RUST_BACKTRACE=1
+    ports:
+      - 55434:55433 # pg protocol handler
+      - 3081:3080 # http endpoints
+    depends_on:
+      - safekeeper-r2-1
+      - safekeeper-r2-2
+      - safekeeper-r2-3
+      - pageserver-r2
+      - xactserver-r2
+  

--- a/docker-compose/docker-compose-multi-region.yml
+++ b/docker-compose/docker-compose-multi-region.yml
@@ -12,10 +12,6 @@ configs:
   compute_shell:
     file: ./compute_wrapper/shell/compute-multi-region.sh
 
-volumes:
-  pageserver-r1-data:
-  pageserver-r2-data:
-
 services:
   etcd:
     restart: always
@@ -73,10 +69,6 @@ services:
     ports:
        #- 6400:6400  # pg protocol handler
        - 9898:9898 # http endpoints
-    # volumes:
-    #   - type: volume
-    #     source: pageserver-r1-data
-    #     target: /data
     entrypoint:
       - "/bin/sh"
       - "-c"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,9 +1,12 @@
 # This YAML can be run using either docker-compose (single node) or Docker Swarm (multiple nodes).
 # 
 # Run with docker-compose:
+#   - Build the wrapped compute image
 #
-#   - To start this stack, change to the directory of this file and run:
+#       docker compose build
 #
+#   - To start the stack, change to the directory of this file and run:
+#       
 #       docker compose up -d
 #
 #   - The compute node will be available on port 55433 (password is "cloud_admin"):


### PR DESCRIPTION
These files are adapted from the existing files in `docker-compose` directory.

This config is for a 2-region setup only. Adding a new region is straight-forward, just copy and paste from existing regions and change the numbering. 

Tested with docker-compose but not tested on Docker Swarm yet but this should be very close. 

There are a few extra steps before running `docker compose up` with this config so I'll write some instructions soon.