### PR TITLE
Support GLOBAL_REGION in remotexact extension

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -392,6 +392,7 @@ impl PostgresNode {
             &format!("postgresql://{}", &self.env.xactserver.listen_pg_addr),
         );
         conf.append("current_region", &self.region_id.to_string());
+        conf.append("multi_region", "on");
 
         let mut file = File::create(self.pgdata().join("postgresql.conf"))?;
         file.write_all(conf.to_string().as_bytes())?;

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -271,16 +271,15 @@ rx_collect_insert(Relation relation, HeapTuple newtuple)
 {
 	StringInfo	buf = NULL;
 	int region = RelationGetRegion(relation);
+	#if PG_VERSION_NUM >= 150000
+		TupleTableSlot *newslot;
+	#endif
 
 	if (region == GLOBAL_REGION && current_region != GLOBAL_REGION)
 	{
 		ereport(ERROR, errmsg("[remotexact] attempting to write to a read-only region."));
 		return;
 	}
-
-#if PG_VERSION_NUM >= 150000
-	TupleTableSlot *newslot;
-#endif
 
 	init_rwset_collection_buffer(relation->rd_node.dbNode);
 


### PR DESCRIPTION
This change modifies the remotexact plugin to avoid collecting GLOBAL_REGION for validation. Additionally, since GLOBAL_REGION is setup as a READ-ONLY region, it disallows writes, updates, and deletes.

I carried out tests by populating the main region before branch creation are read the data from other regions (r1, r2, etc.). Also tried to insert data into the main region from r1, r2, etc; this is disallowed by the remotexact extension. 

The main region can also read data from r1, r2, etc. It can even execute remote writes, updates and deletes. This makes the main region ideal for carrying out catalog-related updates. 

Two major downsides: 

1. The pagestream periodically gets the latest LSN from the GLOBAL_REGION to all active page servers. Therefore it fetches updates for subsequent reads. So it gives us invalidation for free. (However, ideally, we would want a way to trigger it manually?) 
