### PR TITLE
Allow running postgres with valgrind

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
         .expect("Postgres connection string is required");
     let spec = matches.get_one::<String>("spec");
     let spec_path = matches.get_one::<String>("spec-path");
+    let valgrind = matches.get_one::<String>("valgrind");
 
     // Try to use just 'postgres' if no path is provided
     let pgbin = matches.get_one::<String>("pgbin").unwrap();
@@ -128,6 +129,7 @@ fn main() -> Result<()> {
         connstr: Url::parse(connstr).context("cannot parse connstr as a URL")?,
         pgdata: pgdata.to_string(),
         pgbin: pgbin.to_string(),
+        valgrind: valgrind.cloned(),
         spec,
         tenant,
         timeline,
@@ -230,6 +232,7 @@ fn cli() -> clap::Command {
                 .long("spec-path")
                 .value_name("SPEC_PATH"),
         )
+        .arg(Arg::new("valgrind").long("valgrind").value_name("VALGRIND"))
 }
 
 #[test]

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -39,6 +39,7 @@ pub struct ComputeNode {
     pub connstr: url::Url,
     pub pgdata: String,
     pub pgbin: String,
+    pub valgrind: Option<String>,
     pub spec: ComputeSpec,
     pub tenant: String,
     pub timeline: String,
@@ -237,10 +238,22 @@ impl ComputeNode {
         let pgdata_path = Path::new(&self.pgdata);
 
         // Run postgres as a child process.
-        let mut pg = Command::new(&self.pgbin)
-            .args(["-D", &self.pgdata])
-            .spawn()
-            .expect("cannot start postgres process");
+        let mut pg = if let Some(valgrind) = self.valgrind.as_ref() {
+            let mut valgrind_tok = valgrind.split_whitespace();
+            let valgrind_bin = valgrind_tok.next().expect("invalid valgrind command");
+            let mut args = valgrind_tok.collect::<Vec<_>>();
+
+            args.extend([&self.pgbin, "-D", &self.pgdata]);
+            Command::new(valgrind_bin)
+                .args(args)
+                .spawn()
+                .expect("cannot start postgres process")
+        } else {
+            Command::new(&self.pgbin)
+                .args(["-D", &self.pgdata])
+                .spawn()
+                .expect("cannot start postgres process")
+        };
 
         wait_for_postgres(&mut pg, pgdata_path)?;
 

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -686,9 +686,11 @@ fn handle_pg(pg_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
                 None
             };
 
+            let valgrind = sub_args.get_one::<String>("valgrind");
+
             if let Some(node) = node {
                 println!("Starting existing postgres {node_name}...");
-                node.start(&auth_token)?;
+                node.start(&auth_token, valgrind)?;
             } else {
                 let branch_name = sub_args
                     .get_one::<String>("branch-name")
@@ -724,7 +726,7 @@ fn handle_pg(pg_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
                     pg_version,
                     region_id,
                 )?;
-                node.start(&auth_token)?;
+                node.start(&auth_token, valgrind)?;
             }
         }
         "stop" => {
@@ -982,6 +984,11 @@ fn cli() -> Command {
         .help("Specify Lsn on the timeline to start from. By default, end of the timeline would be used.")
         .required(false);
 
+    let valgrind_arg = Arg::new("valgrind")
+        .long("valgrind")
+        .help("Valgrind command to start the compute node with.")
+        .required(false);
+
     Command::new("Neon CLI")
         .arg_required_else_help(true)
         .version(GIT_VERSION)
@@ -1118,6 +1125,7 @@ fn cli() -> Command {
                     .arg(lsn_arg)
                     .arg(port_arg)
                     .arg(pg_version_arg)
+                    .arg(valgrind_arg)
                 )
                 .subcommand(
                     Command::new("stop")

--- a/docker-compose/compute_wrapper/Dockerfile
+++ b/docker-compose/compute_wrapper/Dockerfile
@@ -1,13 +1,14 @@
 ARG REPOSITORY=neondatabase
 ARG COMPUTE_IMAGE=compute-node-v14
-ARG TAG=latest
+ARG TAG=test
 
 FROM $REPOSITORY/${COMPUTE_IMAGE}:$TAG
 
 USER root
-RUN apt-get update &&       \
-    apt-get install -y curl \
-                       jq   \
-                       netcat
+RUN apt-get update &&           \
+    apt-get install -y curl     \
+                       jq       \
+                       netcat   \
+                       valgrind
 
 USER postgres

--- a/docker-compose/compute_wrapper/shell/compute-multi-region.sh
+++ b/docker-compose/compute_wrapper/shell/compute-multi-region.sh
@@ -3,7 +3,7 @@ set -eux
 
 PG_VERSION=${PG_VERSION:-14}
 
-SPEC_FILE_ORG=/var/db/postgres/specs/spec-multi-region.json
+SPEC_FILE_ORIGINAL=/var/db/postgres/specs/spec-multi-region.json
 SPEC_FILE=/tmp/spec.json
 
 echo "Waiting pageserver become ready."
@@ -32,7 +32,7 @@ echo "Tenant id: ${tenant_id}"
 echo "Timeline id: ${timeline_id}"
 
 echo "Overwrite variables in spec file"
-sed "s/TENANT_ID/${tenant_id}/" ${SPEC_FILE_ORG} > ${SPEC_FILE}
+sed "s/TENANT_ID/${tenant_id}/" ${SPEC_FILE_ORIGINAL} > ${SPEC_FILE}
 sed -i "s/TIMELINE_ID/${timeline_id}/" ${SPEC_FILE}
 sed -i "s/SAFEKEEPERS_ADDR/${SAFEKEEPERS_ADDR}/" ${SPEC_FILE}
 sed -i "s/PAGESERVER_HOST/${PAGESERVER_HOST}/" ${SPEC_FILE}
@@ -42,7 +42,12 @@ sed -i "s/REGION/${REGION}/" ${SPEC_FILE}
 cat ${SPEC_FILE}
 
 echo "Start compute node"
-/usr/local/bin/compute_ctl --pgdata /var/db/postgres/compute \
-     -C "postgresql://cloud_admin@localhost:55433/postgres"  \
-     -b /usr/local/bin/postgres                              \
+/usr/local/bin/compute_ctl --pgdata /var/db/postgres/compute                    \
+     -C "postgresql://cloud_admin@localhost:55433/postgres"                     \
+     -b /usr/local/bin/postgres                                                 \
      -S ${SPEC_FILE}
+     # --valgrind "valgrind --leak-check=no                                       \
+     #                      --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END \
+     #                      --suppressions=/shell/valgrind.supp                   \
+     #                      --trace-children=yes                                  \
+     #                      --time-stamp=yes"                                     

--- a/docker-compose/compute_wrapper/valgrind.supp
+++ b/docker-compose/compute_wrapper/valgrind.supp
@@ -1,0 +1,200 @@
+# This is a suppression file for use with Valgrind tools.  File format
+# documentation:
+#	http://valgrind.org/docs/manual/mc-manual.html#mc-manual.suppfiles
+
+# The libc symbol that implements a particular standard interface is
+# implementation-dependent.  For example, strncpy() shows up as "__GI_strncpy"
+# on some platforms.  Use wildcards to avoid mentioning such specific names.
+# Avoid mentioning functions that are good candidates for inlining,
+# particularly single-caller static functions.  Suppressions mentioning them
+# would be ineffective at higher optimization levels.
+
+
+# We have occasion to write raw binary structures to disk or to the network.
+# These may contain uninitialized padding bytes.  Since recipients also ignore
+# those bytes as padding, this is harmless.
+
+{
+	padding_pgstat_send
+	Memcheck:Param
+	socketcall.send(msg)
+
+	fun:*send*
+	fun:pgstat_send
+}
+
+{
+	padding_pgstat_sendto
+	Memcheck:Param
+	socketcall.sendto(msg)
+
+	fun:*send*
+	fun:pgstat_send
+}
+
+{
+	padding_pgstat_write
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:pgstat_write_statsfiles
+}
+
+{
+	padding_XLogRecData_CRC
+	Memcheck:Value8
+
+	fun:pg_comp_crc32c*
+	fun:XLogRecordAssemble
+}
+
+{
+	padding_XLogRecData_write
+	Memcheck:Param
+	pwrite64(buf)
+
+	...
+	fun:XLogWrite
+}
+
+{
+	padding_relcache
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:write_relcache_init_file
+}
+
+{
+	padding_reorderbuffer_serialize
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:ReorderBufferSerializeTXN
+}
+
+{
+	padding_twophase_prepare
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:EndPrepare
+}
+
+
+{
+	padding_twophase_CRC
+	Memcheck:Value8
+	fun:pg_comp_crc32c*
+	fun:EndPrepare
+}
+
+{
+	padding_bootstrap_initial_xlog_write
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:BootStrapXLOG
+}
+
+{
+	padding_bootstrap_control_file_write
+	Memcheck:Param
+	write(buf)
+
+	...
+	fun:WriteControlFile
+	fun:BootStrapXLOG
+}
+
+{
+	bootstrap_write_relmap_overlap
+	Memcheck:Overlap
+	fun:memcpy*
+	fun:write_relmap_file
+	fun:RelationMapFinishBootstrap
+}
+
+
+# gcc on ppc64 can generate a four-byte read to fetch the final "char" fields
+# of a FormData_pg_cast.  This is valid compiler behavior, because a proper
+# FormData_pg_cast has trailing padding.  Tuples we treat as structures omit
+# that padding, so Valgrind reports an invalid read.  Practical trouble would
+# entail the missing pad bytes falling in a different memory page.  So long as
+# the structure is aligned, that will not happen.
+{
+	overread_tuplestruct_pg_cast
+	Memcheck:Addr4
+
+	fun:IsBinaryCoercible
+}
+
+# Python's allocator does some low-level tricks for efficiency. Those
+# can be disabled for better instrumentation; but few people testing
+# postgres will have such a build of python. So add broad
+# suppressions of the resulting errors.
+# See also https://svn.python.org/projects/python/trunk/Misc/README.valgrind
+{
+   python_clever_allocator
+   Memcheck:Addr4
+   fun:PyObject_Free
+}
+
+{
+   python_clever_allocator
+   Memcheck:Addr8
+   fun:PyObject_Free
+}
+
+{
+   python_clever_allocator
+   Memcheck:Value4
+   fun:PyObject_Free
+}
+
+{
+   python_clever_allocator
+   Memcheck:Value8
+   fun:PyObject_Free
+}
+
+{
+   python_clever_allocator
+   Memcheck:Cond
+   fun:PyObject_Free
+}
+
+{
+   python_clever_allocator
+   Memcheck:Addr4
+   fun:PyObject_Realloc
+}
+
+{
+   python_clever_allocator
+   Memcheck:Addr8
+   fun:PyObject_Realloc
+}
+
+{
+   python_clever_allocator
+   Memcheck:Value4
+   fun:PyObject_Realloc
+}
+
+{
+   python_clever_allocator
+   Memcheck:Value8
+   fun:PyObject_Realloc
+}
+
+{
+   python_clever_allocator
+   Memcheck:Cond
+   fun:PyObject_Realloc
+}

--- a/docker-compose/docker-compose-multi-region.yml
+++ b/docker-compose/docker-compose-multi-region.yml
@@ -62,6 +62,8 @@ configs:
     file: ./compute_wrapper/var/db/postgres/specs/spec-multi-region.json
   compute_shell:
     file: ./compute_wrapper/shell/compute-multi-region.sh
+  valgrind_supp:
+    file: ./compute_wrapper/valgrind.supp
   prometheus:
     file: ./prometheus.yml
 
@@ -259,6 +261,8 @@ services:
       - source: compute_shell
         target: /shell/compute-multi-region.sh
         mode: 0555 # readable and executable
+      - source: valgrind_supp
+        target: /shell/valgrind.supp
     ports:
       - 55433:55433 # pg protocol handler
     entrypoint:


### PR DESCRIPTION
For local development, postgresql can be run with valgrind using:

```bash
 target/debug/neon_local pg start main --valgrind                                                \
  "valgrind --leak-check=no                                                                      \
            --error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END                                \
            --suppressions=<path-to-neon>/docker-compose/compute_wrapper/valgrind.supp           \
            --trace-children=yes                                                                 \
            --time-stamp=yes"
```

For deployment with docker compose/swarm, uncomment the valgrind part, and add a backslash at the end of the previous line in file `docker-compose/compute_wrapper/shell/compute-multi-region.sh`