### PR TITLE
Abort transaction with proper abort info

### DIFF
--- a/pgxn/remotexact/apply.c
+++ b/pgxn/remotexact/apply.c
@@ -309,9 +309,9 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 		 */
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("surrogate transaction did not find row to be updated "
+				 errmsg("[remotexact] surrogate transaction did not find row to be updated "
 				   	    "in relation \"%s\"",
-					    RelationGetRelationName(localrel))));
+					      RelationGetRelationName(localrel))));
 	}
 
 	/* Cleanup. */
@@ -403,9 +403,9 @@ apply_handle_delete_internal(ApplyExecutionData *edata,
 		 */
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_CORRUPTED),
-				 errmsg("surrogate transaction did not find row to be deleted "
+				 errmsg("[remotexact] surrogate transaction did not find row to be deleted "
 				   	    "in relation \"%s\"",
-					    RelationGetRelationName(localrel))));
+					      RelationGetRelationName(localrel))));
 	}
 
 	/* Cleanup. */
@@ -471,7 +471,7 @@ open_relation(LogicalRepRelId relid, LOCKMODE lockmode)
     if (!OidIsValid(relid))
         ereport(ERROR,
                 (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-                    errmsg("relation with id \"%d\" does not exist", relid)));
+                 errmsg("[remotexact] relation with id \"%d\" does not exist", relid)));
 
     return table_open(relid, lockmode);
 }
@@ -498,9 +498,9 @@ check_relation_updatable(Relation rel)
 		relreplident != REPLICA_IDENTITY_INDEX)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				errmsg("target relation \"%s\" has neither REPLICA IDENTITY "
-					   "index nor REPLICA IDENTITY FULL",
-						RelationGetRelationName(rel))));
+				 errmsg("[remotexact] target relation \"%s\" has neither REPLICA IDENTITY "
+					      "index nor REPLICA IDENTITY FULL",
+						    RelationGetRelationName(rel))));
 }
 
 /*
@@ -661,8 +661,8 @@ slot_store_data(TupleTableSlot *slot, Relation rel,
 				if (colvalue->cursor != colvalue->len)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
-							 errmsg("incorrect binary data format in logical replication column %d",
-									i + 1)));
+							 errmsg("[remotexact] incorrect binary data format in logical replication column %d",
+									    i + 1)));
 				slot->tts_isnull[i] = false;
 			}
 			else
@@ -769,8 +769,8 @@ slot_modify_data(TupleTableSlot *slot, TupleTableSlot *srcslot,
 				if (colvalue->cursor != colvalue->len)
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
-							 errmsg("incorrect binary data format in logical replication column %d",
-									i + 1)));
+							 errmsg("[remotexact] incorrect binary data format in logical replication column %d",
+									    i + 1)));
 				slot->tts_isnull[i] = false;
 			}
 			else

--- a/pgxn/remotexact/apply.c
+++ b/pgxn/remotexact/apply.c
@@ -308,10 +308,10 @@ apply_handle_update_internal(ApplyExecutionData *edata,
 		 * transaction.
 		 */
 		ereport(ERROR,
-			(errcode(ERRCODE_DATA_CORRUPTED),
-			errmsg("surrogate transaction did not find row to be updated "
-				   "in relation \"%s\"",
-					RelationGetRelationName(localrel))));
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("surrogate transaction did not find row to be updated "
+				   	    "in relation \"%s\"",
+					    RelationGetRelationName(localrel))));
 	}
 
 	/* Cleanup. */
@@ -402,10 +402,10 @@ apply_handle_delete_internal(ApplyExecutionData *edata,
 		 * transaction.
 		 */
 		ereport(ERROR,
-			(errcode(ERRCODE_DATA_CORRUPTED),
-			errmsg("surrogate transaction did not find row to be deleted "
-				   "in relation \"%s\"",
-					RelationGetRelationName(localrel))));
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("surrogate transaction did not find row to be deleted "
+				   	    "in relation \"%s\"",
+					    RelationGetRelationName(localrel))));
 	}
 
 	/* Cleanup. */

--- a/pgxn/remotexact/validate.c
+++ b/pgxn/remotexact/validate.c
@@ -73,8 +73,8 @@ void validate_index_scan(RWSetRelation *rw_rel)
 
     if (page_lsn > read_csn) {
         ereport(ERROR,
-        (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-            errmsg("read out-of-date index data from a remote partition")));
+                (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+                 errmsg("[remotexact] read out-of-date index data from a remote partition")));
     }
 }
 
@@ -178,7 +178,7 @@ validate_table_scan(RWSetRelation *rw_rel)
             CSNLogGetCSNByXid(current_region, checked_xid) > read_csn)
             ereport(ERROR,
                     (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-                        errmsg("read out-of-date data from a remote partition")));
+                     errmsg("[remotexact] read out-of-date data from a remote partition")));
 
     }
 
@@ -236,8 +236,8 @@ validate_tuple_scan(RWSetRelation *rw_rel)
 
         if (!valid)
             ereport(ERROR,
-                (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-                errmsg("read out-of-date tuple data from a remote partition")));
+                    (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+                     errmsg("[remotexact] read out-of-date tuple data from a remote partition")));
     }
 
 


### PR DESCRIPTION
Use the rollback information from the xact server to abort the transaction with extra information (e.g. errcode to tell whether the abort is due to deadlock or not). 