### PR TITLE
Dedicated endpoint for getting latest lsn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4918,6 +4918,7 @@ dependencies = [
  "syn",
  "tokio",
  "tokio-util",
+ "toml_datetime",
  "tonic",
  "tower",
  "tracing",

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -413,6 +413,7 @@ pub enum PagestreamFeMessage {
     GetPage(PagestreamGetPageRequest),
     DbSize(PagestreamDbSizeRequest),
     GetSlruPage(PagestreamGetSlruPageRequest),
+    GetLatestLsn(PagestreamGetLatestLsnRequest),
 }
 
 // Wrapped in libpq CopyData
@@ -421,6 +422,7 @@ pub enum PagestreamBeMessage {
     Nblocks(PagestreamNblocksResponse),
     GetPage(PagestreamGetPageResponse),
     GetSlruPage(PagestreamGetSlruPageResponse),
+    GetLatestLsn(PagestreamGetLatestLsnResponse),
     Error(PagestreamErrorResponse),
     DbSize(PagestreamDbSizeResponse),
 }
@@ -468,6 +470,11 @@ pub struct PagestreamGetSlruPageRequest {
     pub check_exists_only: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct PagestreamGetLatestLsnRequest {
+    pub region: RegionId,
+}
+
 #[derive(Debug)]
 pub struct PagestreamExistsResponse {
     pub lsn: Lsn,
@@ -491,6 +498,11 @@ pub struct PagestreamGetSlruPageResponse {
     pub lsn: Lsn,
     pub seg_exists: bool,
     pub page: Option<Bytes>,
+}
+
+#[derive(Debug)]
+pub struct PagestreamGetLatestLsnResponse {
+    pub lsn: Lsn,
 }
 
 #[derive(Debug)]
@@ -551,7 +563,7 @@ impl PagestreamFeMessage {
             }
 
             Self::GetSlruPage(req) => {
-                bytes.put_u8(4); /* tag from pagestore_client.h */
+                bytes.put_u8(4);
                 bytes.put_u8(u8::from(req.latest));
                 bytes.put_u64(req.lsn.0);
                 bytes.put_u8(req.region.0);
@@ -559,6 +571,11 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.segno);
                 bytes.put_u32(req.blkno);
                 bytes.put_u8(u8::from(req.check_exists_only));
+            }
+
+            Self::GetLatestLsn(req) => {
+                bytes.put_u8(5);
+                bytes.put_u8(req.region.0);
             }
         }
 
@@ -624,6 +641,11 @@ impl PagestreamFeMessage {
                     check_exists_only: body.read_u8()? != 0,
                 },
             )),
+            5 => Ok(PagestreamFeMessage::GetLatestLsn(
+                PagestreamGetLatestLsnRequest {
+                    region: RegionId(body.read_u8()?),
+                },
+            )),
             _ => bail!("unknown smgr message tag: {:?}", msg_tag),
         }
     }
@@ -664,13 +686,18 @@ impl PagestreamBeMessage {
                 }
             }
 
-            Self::Error(resp) => {
+            Self::GetLatestLsn(resp) => {
                 bytes.put_u8(104); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
+            }
+
+            Self::Error(resp) => {
+                bytes.put_u8(105); /* tag from pagestore_client.h */
                 bytes.put(resp.message.as_bytes());
                 bytes.put_u8(0); // null terminator
             }
             Self::DbSize(resp) => {
-                bytes.put_u8(105); /* tag from pagestore_client.h */
+                bytes.put_u8(106); /* tag from pagestore_client.h */
                 bytes.put_u64(resp.lsn.0);
                 bytes.put_i64(resp.db_size);
             }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -17,9 +17,9 @@ use pageserver_api::models::TenantState;
 use pageserver_api::models::{
     PagestreamBeMessage, PagestreamDbSizeRequest, PagestreamDbSizeResponse,
     PagestreamErrorResponse, PagestreamExistsRequest, PagestreamExistsResponse,
-    PagestreamFeMessage, PagestreamGetPageRequest, PagestreamGetPageResponse,
-    PagestreamGetSlruPageRequest, PagestreamGetSlruPageResponse, PagestreamNblocksRequest,
-    PagestreamNblocksResponse,
+    PagestreamFeMessage, PagestreamGetLatestLsnResponse, PagestreamGetPageRequest,
+    PagestreamGetPageResponse, PagestreamGetSlruPageRequest, PagestreamGetSlruPageResponse,
+    PagestreamNblocksRequest, PagestreamNblocksResponse,
 };
 use pq_proto::ConnectionError;
 use pq_proto::FeStartupPacket;
@@ -232,6 +232,7 @@ struct PageRequestMetrics {
     get_page_at_lsn: metrics::Histogram,
     get_db_size: metrics::Histogram,
     get_slru_page: metrics::Histogram,
+    get_latest_lsn: metrics::Histogram,
 }
 
 impl PageRequestMetrics {
@@ -254,12 +255,16 @@ impl PageRequestMetrics {
         let get_slru_page =
             SMGR_QUERY_TIME.with_label_values(&["get_slru_page", &tenant_id, &timeline_id]);
 
+        let get_latest_lsn =
+            SMGR_QUERY_TIME.with_label_values(&["get_latest_lsn", &tenant_id, &timeline_id]);
+
         Self {
             get_rel_exists,
             get_rel_size,
             get_page_at_lsn,
             get_db_size,
             get_slru_page,
+            get_latest_lsn,
         }
     }
 }
@@ -415,6 +420,13 @@ impl PageServerHandler {
                             self.handle_get_slru_page_at_lsn_request(&timeline, &req, &ctx)
                                 .await
                         }
+                        Err(e) => Err(e),
+                    }
+                }
+                PagestreamFeMessage::GetLatestLsn(req) => {
+                    let _timer = metrics.get_latest_lsn.start_timer();
+                    match get_timeline_by_region_id(&timelines, req.region) {
+                        Ok(timeline) => self.handle_get_latest_lsn_request(&timeline, &ctx).await,
                         Err(e) => Err(e),
                     }
                 }
@@ -757,6 +769,21 @@ impl PageServerHandler {
                 seg_exists,
                 page,
             },
+        ))
+    }
+
+    #[instrument(skip(self, timeline, ctx), fields(region = %timeline.region_id))]
+    async fn handle_get_latest_lsn_request(
+        &self,
+        timeline: &Timeline,
+        ctx: &RequestContext,
+    ) -> anyhow::Result<PagestreamBeMessage> {
+        let latest_gc_cutoff_lsn = timeline.get_latest_gc_cutoff_lsn();
+        let lsn =
+            Self::wait_or_get_last_lsn(timeline, Lsn(0), true, &latest_gc_cutoff_lsn, ctx).await?;
+
+        Ok(PagestreamBeMessage::GetLatestLsn(
+            PagestreamGetLatestLsnResponse { lsn },
         ))
     }
 

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -273,9 +273,6 @@ pageserver_receive(int region)
 				neon_log(PageStoreTrace, "got response: %s", msg);
 				pfree(msg);
 			}
-
-			/* Remotexact */
-			set_region_lsn(region, resp);
 		}
 		else if (rc == -1)
 		{
@@ -576,4 +573,5 @@ pg_init_libpagestore(void)
 
 	get_region_lsn_hook = get_region_lsn;
 	get_all_region_lsns_hook = get_all_region_lsns;
+	clear_region_lsns();
 }

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -25,72 +25,26 @@
 #include "utils/varlena.h"
 #include "walproposer_utils.h"
 
+/* Track the first LSN we get from the pageserver for a region */
 static XLogRecPtr	region_lsns[MAX_REGIONS];
 
 /*
- * Set the LSN for a given region if it wasn't previously set. 
- * This LSN is used in Neon requests for that region throughout
- * the life of the current transaction.
- */
-void
-set_region_lsn(int region, NeonResponse *msg)
-{
-	XLogRecPtr lsn = InvalidXLogRecPtr;
-
-	if (!IsMultiRegion() || !RegionIsRemote(region))
-		return;
-
-	AssertArg(region < MAX_REGIONS);
-
-	switch (messageTag(msg))
-	{
-		case T_NeonExistsResponse:
-			lsn = ((NeonExistsResponse *) msg)->lsn;
-			break;
-		case T_NeonNblocksResponse:
-			lsn = ((NeonNblocksResponse *) msg)->lsn;
-			break;
-		case T_NeonGetPageResponse:
-			lsn = ((NeonGetPageResponse *) msg)->lsn;
-			break;
-		case T_NeonGetSlruPageResponse:
-			lsn = ((NeonGetSlruPageResponse *) msg)->lsn;
-			break;
-		case T_NeonDbSizeResponse:
-			lsn = ((NeonDbSizeResponse *) msg)->lsn;
-			break;
-		case T_NeonErrorResponse:
-			break;
-		default:
-			neon_log(ERROR, "unexpected neon message tag 0x%02x", messageTag(msg));
-			break;
-	}
-
-	if (lsn == InvalidXLogRecPtr)
-	{
-		neon_log(WARNING, "region lsn is InvalidXLogRecPtr");
-		return;
-	}
-
-	if (region_lsns[region] == InvalidXLogRecPtr)
-		region_lsns[region] = lsn;
-
-	Assert(region_lsns[region] == lsn);
-}
-
-/*
- * Get the LSN of a region
+ * Get the LSN of a region. The caller must 
  */
 XLogRecPtr
 get_region_lsn(int region)
 {
-	if (!IsMultiRegion())
-		return InvalidXLogRecPtr;
-	
-	// LSN of the current region is already tracked by postgres
+	Assert(IsMultiRegion());	
+
+	/*
+	 * LSN of the current region is already tracked by postgres
+	 */
 	AssertArg(region != current_region);
 	AssertArg(region < MAX_REGIONS);
-	// TODO(ctring): If this is 0, proactively contact neon for the latest lsn
+
+	if (region_lsns[region] == InvalidXLogRecPtr)
+		region_lsns[region] = neon_get_latest_lsn(region);
+
 	return region_lsns[region];
 }
 

--- a/pgxn/neon/multiregion.h
+++ b/pgxn/neon/multiregion.h
@@ -14,7 +14,6 @@
 #include "access/xlogdefs.h"
 #include "pagestore_client.h"
 
-extern void set_region_lsn(int region, NeonResponse *msg);
 extern XLogRecPtr get_region_lsn(int region);
 extern XLogRecPtr *get_all_region_lsns(void);
 extern void clear_region_lsns(void);

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -34,12 +34,14 @@ typedef enum
 	T_NeonGetPageRequest,
 	T_NeonDbSizeRequest,
 	T_NeonGetSlruPageRequest,
+	T_NeonGetLatestLsnRequest,
 
 	/* pagestore -> pagestore_client */
 	T_NeonExistsResponse = 100,
 	T_NeonNblocksResponse,
 	T_NeonGetPageResponse,
 	T_NeonGetSlruPageResponse,
+	T_NeonGetLatestLsnResponse,
 	T_NeonErrorResponse,
 	T_NeonDbSizeResponse,
 }			NeonMessageTag;
@@ -119,6 +121,11 @@ typedef struct
 	bool check_exists_only;
 } NeonGetSlruPageRequest;
 
+typedef struct
+{
+	NeonRequest req;
+} NeonGetLatestLsnRequest;
+
 /* supertype of all the Neon*Response structs below */
 typedef struct
 {
@@ -163,6 +170,12 @@ typedef struct
 	bool		page_exists;
 	char		page[FLEXIBLE_ARRAY_MEMBER];
 } NeonGetSlruPageResponse;
+
+typedef struct
+{
+	NeonMessageTag tag;
+	XLogRecPtr lsn;
+} NeonGetLatestLsnResponse;
 
 typedef struct
 {
@@ -248,11 +261,14 @@ extern bool lfc_read(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno, c
 extern bool lfc_cache_contains(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno);
 extern void lfc_init(void);
 
-/* neon SLRU functionality */
+/* Remotexact - neon SLRU functionality */
 extern const char *slru_kind_to_string(NeonSlruKind kind);
 extern bool slru_kind_from_string(const char* str, NeonSlruKind* kind);
 extern bool neon_slru_kind_check(SlruCtl ctl);
 extern bool neon_slru_read_page(SlruCtl ctl, int segno, BlockNumber blkno, XLogRecPtr min_lsn, char *buffer);
 extern bool neon_slru_page_exists(SlruCtl ctl, int segno, BlockNumber blkno);
+
+/* Remotexact - used for tracking lsns of different regions */
+extern XLogRecPtr neon_get_latest_lsn(int region);
 
 #endif

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -968,12 +968,23 @@ nm_pack_request(NeonRequest * msg)
 
 				break;
 			}
+		
+		case T_NeonGetLatestLsnRequest:
+			{
+				NeonGetLatestLsnRequest *msg_req = (NeonGetLatestLsnRequest *) msg;
+
+				pq_sendint8(&s, msg_req->req.region);
+
+				break;
+			}
+
 
 			/* pagestore -> pagestore_client. We never need to create these. */
 		case T_NeonExistsResponse:
 		case T_NeonNblocksResponse:
 		case T_NeonGetPageResponse:
 		case T_NeonGetSlruPageResponse:
+		case T_NeonGetLatestLsnResponse:
 		case T_NeonErrorResponse:
 		case T_NeonDbSizeResponse:
 		default:
@@ -1062,6 +1073,17 @@ nm_unpack_response(StringInfo s)
 					memcpy(msg_resp->page, pq_getmsgbytes(s, BLCKSZ), BLCKSZ);
 				}
 				pq_getmsgend(s);
+
+				resp = (NeonResponse *) msg_resp;
+				break;
+			}
+		
+		case T_NeonGetLatestLsnResponse:
+			{
+				NeonGetLatestLsnResponse *msg_resp = palloc0(sizeof(NeonGetLatestLsnResponse));
+
+				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 
 				resp = (NeonResponse *) msg_resp;
 				break;
@@ -1193,6 +1215,16 @@ nm_to_string(NeonMessage * msg)
 				break;
 			}
 
+		case T_NeonGetLatestLsnRequest:
+			{
+				NeonGetLatestLsnRequest *msg_req = (NeonGetLatestLsnRequest *) msg;
+
+				appendStringInfoString(&s, "{\"type\": \"NeonGetLatestLsnRequest\"");
+				appendStringInfo(&s, ", \"region\": %d", msg_req->req.region);
+				appendStringInfoChar(&s, '}');
+				break;
+			}
+
 			/* pagestore -> pagestore_client */
 		case T_NeonExistsResponse:
 			{
@@ -1238,6 +1270,15 @@ nm_to_string(NeonMessage * msg)
 				appendStringInfo(&s, ", \"seg_exists\": %d", msg_resp->seg_exists);
 				appendStringInfo(&s, ", \"page_exists\": %d", msg_resp->page_exists);
 				appendStringInfo(&s, ", \"page\": \"XXX\"}");
+				appendStringInfoChar(&s, '}');
+				break;
+			}
+		case T_NeonGetLatestLsnResponse:
+			{
+				NeonGetLatestLsnResponse *msg_resp = (NeonGetLatestLsnResponse *) msg;
+
+				appendStringInfoString(&s, "{\"type\": \"NeonGetLatestLsnResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
 				appendStringInfoChar(&s, '}');
 				break;
 			}
@@ -2755,9 +2796,9 @@ smgr_init_neon(void)
 	neon_init();
 }
 
-/*
- * SLRU stuff
- */
+/**************************************
+ * 			Remotexact stuff
+ **************************************/
 
 const char *
 slru_kind_to_string(NeonSlruKind kind)
@@ -2979,7 +3020,8 @@ neon_slru_page_exists(SlruCtl ctl, int segno, BlockNumber blkno)
 	{
 		case T_NeonGetSlruPageResponse:
 			exists = ((NeonGetSlruPageResponse *) resp)->page_exists;
-			break;
+			pfree(resp);
+			return exists;
 
 		case T_NeonErrorResponse:
 			ereport(ERROR,
@@ -2999,7 +3041,40 @@ neon_slru_page_exists(SlruCtl ctl, int segno, BlockNumber blkno)
 			elog(ERROR, "unexpected response from page server with tag 0x%02x", resp->tag);
 	}
 
-	pfree(resp);
-
-	return exists;
+	pg_unreachable();
 } 
+
+XLogRecPtr
+neon_get_latest_lsn(int region)
+{
+	NeonResponse	*resp;
+	XLogRecPtr		latest_lsn;
+	NeonGetLatestLsnRequest request = {
+		.req.tag = T_NeonGetLatestLsnRequest,
+		.req.region = region,
+	};
+
+	resp = page_server_request(&request);
+
+	switch (resp->tag)
+	{
+		case T_NeonGetLatestLsnResponse:
+			latest_lsn = ((NeonGetLatestLsnResponse *) resp)->lsn;
+			pfree(resp);
+			return latest_lsn;
+
+		case T_NeonErrorResponse:
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not get the latest lsn for region %d from the page server",
+							region),
+					 errdetail("page server returned error: %s",
+							   ((NeonErrorResponse *) resp)->message)));
+			break;
+
+		default:
+			elog(ERROR, "unexpected response from page server with tag 0x%02x", resp->tag);
+	}
+
+	pg_unreachable();
+}

--- a/trace/src/main.rs
+++ b/trace/src/main.rs
@@ -74,6 +74,7 @@ fn analyze_trace<R: std::io::Read>(mut reader: R) {
                 prev = Some(req);
             }
             PagestreamFeMessage::GetSlruPage(_) => {}
+            PagestreamFeMessage::GetLatestLsn(_) => {}
             PagestreamFeMessage::DbSize(_) => {}
         };
     }

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "0.5", default-features = false, features = ["serde"] }
 tonic = { version = "0.8", features = ["tls-roots"] }
 tower = { version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
 tracing = { version = "0.1", features = ["log"] }
@@ -70,5 +71,6 @@ regex = { version = "1" }
 regex-syntax = { version = "0.6" }
 serde = { version = "1", features = ["alloc", "derive"] }
 syn = { version = "1", features = ["extra-traits", "full", "visit", "visit-mut"] }
+toml_datetime = { version = "0.5", default-features = false, features = ["serde"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
The previous approach to get an LSN snapshot was to grab the LSN of the first response from the pageserver. However, since the new prefetching mechanism in neon, this approach becomes brittle.

The prefetching mechanism causes the request-response pair to happen asynchronously, so this sequence of events may happen (LSN 0 means we fetch the latest page):

```
Request page 0 @ LSN 0 in region 1
Request page 1 @ LSN 0 in region 1
Response page 0 @ LSN 100 in region 1
Response page 1 @ LSN 101 in region 1
```

A simple fix is to have a dedicated synchronous request to get the latest LSN from neon. This request is sent whenever the LSN for that region is read for the first time. The above events become:

```
Request latest lsn of region 1
Response LSN 100 as latest lsn of region 1 
Request page 0 @ LSN 100 in region 1
Request page 1 @ LSN 100 in region 1
Response page 0 @ LSN 100 in region 1
Response page 1 @ LSN 100 in region 1
```