### PR TITLE
Track remote relation size in a local cache

### DIFF
--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -250,10 +250,11 @@ extern void neon_immedsync(SMgrRelation reln, ForkNumber forknum);
 
 /* utils for neon relsize cache */
 extern void relsize_hash_init(void);
-extern bool get_cached_relsize(RelFileNode rnode, ForkNumber forknum, BlockNumber *size);
-extern void set_cached_relsize(RelFileNode rnode, ForkNumber forknum, BlockNumber size);
-extern void update_cached_relsize(RelFileNode rnode, ForkNumber forknum, BlockNumber size);
+extern bool get_cached_relsize(int region, RelFileNode rnode, ForkNumber forknum, BlockNumber *size);
+extern void set_cached_relsize(int region, RelFileNode rnode, ForkNumber forknum, BlockNumber size);
+extern void update_cached_relsize(int region, RelFileNode rnode, ForkNumber forknum, BlockNumber size);
 extern void forget_cached_relsize(RelFileNode rnode, ForkNumber forknum);
+extern void clear_local_relsize_hash(void); /* Remotexact */
 
 /* functions for local file cache */
 extern void lfc_write(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno, char *buffer);

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1617,7 +1617,7 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 			elog(ERROR, "unknown relpersistence '%c'", reln->smgr_relpersistence);
 	}
 
-	if (get_cached_relsize(reln->smgr_rnode.node, forkNum, &n_blocks))
+	if (get_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forkNum, &n_blocks))
 	{
 		return true;
 	}
@@ -1724,7 +1724,7 @@ neon_create(SMgrRelation reln, ForkNumber forkNum, bool isRedo)
 	 * cache, we might call smgrnblocks() on the newly-created relation before
 	 * the creation WAL record hass been received by the page server.
 	 */
-	set_cached_relsize(reln->smgr_rnode.node, forkNum, 0);
+	set_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forkNum, 0);
 
 #ifdef DEBUG_COMPARE_LOCAL
 	if (IS_LOCAL_REL(reln))
@@ -1833,7 +1833,7 @@ neon_extend(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
 		neon_wallog_page(reln, forkNum, n_blocks++, buffer, true);
 
 	neon_wallog_page(reln, forkNum, blkno, buffer, false);
-	set_cached_relsize(reln->smgr_rnode.node, forkNum, blkno + 1);
+	set_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forkNum, blkno + 1);
 
 	lsn = PageGetLSN(buffer);
 	elog(SmgrTrace, "smgrextend called for %u/%u/%u.%u blk %u, page LSN: %X/%08X",
@@ -2351,7 +2351,7 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 			elog(ERROR, "unknown relpersistence '%c'", reln->smgr_relpersistence);
 	}
 
-	if (get_cached_relsize(reln->smgr_rnode.node, forknum, &n_blocks))
+	if (get_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forknum, &n_blocks))
 	{
 		elog(SmgrTrace, "cached nblocks for %u/%u/%u.%u: %u blocks",
 			 reln->smgr_rnode.node.spcNode,
@@ -2403,12 +2403,7 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 			elog(ERROR, "unexpected response from page server with tag 0x%02x", resp->tag);
 	}
 
-	/*
-	 * Remotexact
-	 * Do not cache relsize of remote relation because it can be changed by another region
-	 */
-	if (!RegionIsRemote(reln->smgr_region))
-		update_cached_relsize(reln->smgr_rnode.node, forknum, n_blocks);
+	update_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forknum, n_blocks);
 
 	elog(SmgrTrace, "neon_nblocks: rel %u/%u/%u fork %u region %d (request LSN %X/%08X): %u blocks",
 		 reln->smgr_rnode.node.spcNode,
@@ -2502,7 +2497,7 @@ neon_truncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks)
 			elog(ERROR, "unknown relpersistence '%c'", reln->smgr_relpersistence);
 	}
 
-	set_cached_relsize(reln->smgr_rnode.node, forknum, nblocks);
+	set_cached_relsize(reln->smgr_region, reln->smgr_rnode.node, forknum, nblocks);
 
 	/*
 	 * Truncating a relation drops all its buffers from the buffer cache
@@ -2730,12 +2725,16 @@ AtEOXact_neon(XactEvent event, void *arg)
 			 */
 			unlogged_build_rel = NULL;
 			unlogged_build_phase = UNLOGGED_BUILD_NOT_IN_PROGRESS;
+			/* Remotexact */
 			clear_region_lsns();
+			clear_local_relsize_hash();
 			break;
 
 		case XACT_EVENT_COMMIT:
 		case XACT_EVENT_PARALLEL_COMMIT:
+			/* Remotexact */
 			clear_region_lsns();
+			clear_local_relsize_hash();
 			/* fall through */
 		case XACT_EVENT_PREPARE:
 		case XACT_EVENT_PRE_COMMIT:


### PR DESCRIPTION
Without this tracking, the following bug may happen:

+ Table X in region 2 has 2 blocks
+ In region 1, run a transaction that adds enough data that extends table X to 3 blocks.
+ In the same transaction, do some query that involves calling the nblocks function for X. This results in a request to pageserver, which returns only 2 blocks since we always read from the same LSN.

In this PR, the relsizes of remote relations are cached in the same manner as neon does but in a hash table local only to the current transaction. Note that we cannot use neon's cache because it is in shared memory and we cannot invalidate it when the relsize is changed by a different region.